### PR TITLE
Tweak parameterization of shell scripts a little bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Next, you can either explore this repository using the included sample XML files
 relatively small), or, if you need complete and up-to-date data, you can download the latest
 MeSH XML files from the NLM server.  The latter option is described first.
 
+
 ### Getting the MeSH XML files
 
 Since the complete MeSH data files are quite large, we assume that they'll be kept
@@ -42,7 +43,7 @@ $MESHRDF_HOME to point to that location.  For example,
 You can run the script *bin/fetch-mesh-xml.sh*, which downloads all the XML and corresponding
 DTD files from the NLM FTP server.  It saves them to the *data* subdirectory of $MESHRDF_HOME.
 
-It downloads the following:
+By default, it downloads the following:
 
 * desc2014.dtd
 * desc2014.xml
@@ -52,6 +53,16 @@ It downloads the following:
 * qual2014.xml
 * supp2014.dtd
 * supp2014.xml
+
+If you want to download a different year's data, set the MESHRDF_YEAR environment variable
+before executing the script. For example,
+
+    MESHRDF_YEAR=2015 bin/fetch-mesh-xml.sh
+
+***Note that at the time of this writing, the 2015 MeSH XML files have not yet been deployed
+to that location.*** To specify the actual location for these files, use this command line:
+
+    MESHRDF_YEAR=2015 MESHRDF_URI=ftp://ftp.nlm.nih.gov/online/mesh/.xmlmesh bin/fetch-mesh-xml.sh
 
 
 ### Getting Saxon
@@ -81,17 +92,33 @@ If your version of Saxon is in a different location, then, of course, set this e
 appropriately.
 
 
-
 ### Converting the complete MeSH data set
 
-There are a few conversion scripts in the repository which you can use to run the
-XSLT conversions.
-
-The conversion script is *mesh-xml2rdf.sh*. This shell script will brute-force convert each of 
+The conversion script is *mesh-xml2rdf.sh*. This shell script will run the XSLTs to convert each of 
 the three main MeSH XML files into RDF N-Triples format, and put the results into the 
-*$MESHRDF_HOME/out* directory. It produces *mesh2014.nt*, which is the RDF in N-triples format, and 
-*mesh2014.nt.gz*, a gzipped version.
+*$MESHRDF_HOME/out* directory. 
 
+By default, it looks for 2014 data files, and will produce *mesh.nt*, which is the 
+RDF in N-triples format, and *mesh.nt.gz*, a gzipped version. Also by default, these 
+data files will have RDF URIs that do not include the year. For example, the descriptor for 
+Ofloxacin would have the URI http://id.nlm.nih.gov/mesh/D015242.
+
+As with the fetch script, described above, you can use the MESHRDF_YEAR environment variable
+to specify that it convert a different set of data files. For example:
+
+    MESHRDF_YEAR=2015 bin/mesh-xml2rdf.sh
+
+This uses the 2015 data files to produce the "current" RDF output files *out/mesh.nt*
+and *out/mesh.nt.gz*.
+
+To produce RDF data that has URIs with the year, then you should also set the
+MESHRDF_URI_YEAR variable to "yes".  Thus, the following uses the 2015 MeSH XML files to
+generate the data that has RDF URIs that include the year:
+
+    MESHRDF_YEAR=2015 MESHRDF_URI_YEAR=yes bin/mesh-xml2rdf.sh
+
+In this case, the output data files will be written to *out/mesh-2015.nt* and
+*out/mesh-2015.nt.gz*.
 
 
 ### Generating and converting the sample files
@@ -180,6 +207,7 @@ documentation](http://data-gov.tw.rpi.edu/wiki/How_to_install_virtuoso_sparql_en
 
     $VIRTUOSO_HOME/bin/isql 1111 dba <password>
     SQL> shutdown();
+
 
 ## Technical documentation on GitHub pages
 

--- a/bin/mesh-xml2rdf.sh
+++ b/bin/mesh-xml2rdf.sh
@@ -3,10 +3,9 @@
 # This script will convert all of the MeSH XML to RDF, assuming that your machine has
 # enough memory and resources.
 #
-# Another option is to use the Perl script mesh-rdf2xml.pl, which first chops up the
-# huge XML files into manageable chunks, and then passes each chunk through XSLT
-# separately.
-#
+# 
+
+
 
 if [ -z "$MESHRDF_HOME" ]; then
     echo "Please define MESHRDF_HOME environment variable" 1>&2
@@ -21,9 +20,17 @@ fi
 # Can override default year with MESHRDF_YEAR environment variable
 YEAR=${MESHRDF_YEAR:-2014}
 
-# Can override default Mesh prefix and output file with MESHRDF_PREFIX environment variable
-PREFIX=${MESHRDF_PREFIX:-mesh/$YEAR}
-OUT=`echo $PREFIX | sed -e 's,/,,'`
+# Override the default Mesh prefix and output file by setting MESHRDF_URI_YEAR to "yes"
+if [ "$MESHRDF_URI_YEAR" = "yes" ]; then
+    PREFIX=mesh/$YEAR
+    OUT=mesh$YEAR
+else
+    PREFIX=mesh
+    OUT=mesh
+fi
+
+#echo PREFIX = $PREFIX
+#echo OUT = $OUT
 
 # substitute the prefix into the DTD entity file
 sed -e "s,MESHRDF_PATH,$PREFIX,g" xslt/mesh-rdf-prefixes.ent.template > xslt/mesh-rdf-prefixes.ent
@@ -34,14 +41,14 @@ fi
 
 mkdir -p "$MESHRDF_HOME/out"
 
-java -Xmx2G -jar $SAXON_JAR -s:"$MESHRDF_HOME/data/qual$YEAR.xml" \
+java -Xmx4G -jar $SAXON_JAR -s:"$MESHRDF_HOME/data/qual$YEAR.xml" \
     -xsl:xslt/qual.xsl > "$MESHRDF_HOME/out/$OUT-dups.nt"
 if [ $? -ne 0 ]; then
     echo "Error converting $MESHRDF_HOME/data/qual$YEAR.xml" 1>&2
     exit 1
 fi
 
-java -Xmx2G -jar $SAXON_JAR -s:"$MESHRDF_HOME/data/desc$YEAR.xml" \
+java -Xmx4G -jar $SAXON_JAR -s:"$MESHRDF_HOME/data/desc$YEAR.xml" \
     -xsl:xslt/desc.xsl >> "$MESHRDF_HOME/out/$OUT-dups.nt"
 if [ $? -ne 0 ]; then
     echo "Error converting $MESHRDF_HOME/data/desc$YEAR.xml"
@@ -49,7 +56,7 @@ if [ $? -ne 0 ]; then
 fi
 
 
-java -Xmx2G -jar $SAXON_JAR -s:"$MESHRDF_HOME/data/supp$YEAR.xml" \
+java -Xmx4G -jar $SAXON_JAR -s:"$MESHRDF_HOME/data/supp$YEAR.xml" \
     -xsl:xslt/supp.xsl >> "$MESHRDF_HOME/out/$OUT-dups.nt"
 if [ $? -ne 0 ]; then
     echo "Error converting $MESHRDF_HOME/data/supp$YEAR.xml"

--- a/xslt/mesh-rdf-prefixes.ent.template
+++ b/xslt/mesh-rdf-prefixes.ent.template
@@ -1,5 +1,5 @@
 <!ENTITY mesh "http://id.nlm.nih.gov/MESHRDF_PATH/">
-<!ENTITY meshv "http://id.nlm.nih.gov/mesh/vocab#">
+<!ENTITY meshv "http://id.nlm.nih.gov/MESHRDF_PATH/vocab#">
 <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
 <!ENTITY xs "http://www.w3.org/2001/XMLSchema">


### PR DESCRIPTION
How about this?  I changed the parameters for the mesh-xml2rdf.sh script to 

* MESHRDF_YEAR - same as you had
* MESHRDF_URI_YEAR - set to "yes" to include the year in the generated URIs

I like this better than the MESHRDF_PREFIX that you had, because that gave the user too much freedom.  Also, note that, by default, it generates year-less URIs.