### PR TITLE
add 'dct' prefix

### DIFF
--- a/meta/vocabulary.ttl
+++ b/meta/vocabulary.ttl
@@ -1,4 +1,5 @@
 @prefix : <http://www.w3.org/2002/07/owl#> .
+@prefix dct: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
@@ -18,7 +19,7 @@
 
 ###  http://purl.org/dc/terms/description
 
-<http://purl.org/dc/terms/description> rdf:type :AnnotationProperty .
+dct:description rdf:type :AnnotationProperty .
 
 
 
@@ -35,7 +36,7 @@
 
 <http://id.nlm.nih.gov/mesh/vocab#allowableQualifier> rdf:type :ObjectProperty ;
                                                       
-                                                      <http://purl.org/dc/terms/description> "Relates Descriptors to Qualifiers. A specific Qualifier allowed in combination with the Descriptor." ;
+                                                      dct:description "Relates Descriptors to Qualifiers. A specific Qualifier allowed in combination with the Descriptor." ;
                                                       
                                                       rdfs:range <http://id.nlm.nih.gov/mesh/vocab#Qualifier> .
 
@@ -51,11 +52,11 @@
 
 <http://id.nlm.nih.gov/mesh/vocab#broaderConcept> rdf:type :ObjectProperty ;
                                                   
-                                                  <http://purl.org/dc/terms/description> "Relates 2 instances of the meshv:Concept class, one of which is broader than the other." ;
-                                                  
-                                                  rdfs:domain <http://id.nlm.nih.gov/mesh/vocab#Concept> ;
+                                                  dct:description "Relates 2 instances of the meshv:Concept class, one of which is broader than the other." ;
                                                   
                                                   rdfs:range <http://id.nlm.nih.gov/mesh/vocab#Concept> ;
+                                                  
+                                                  rdfs:domain <http://id.nlm.nih.gov/mesh/vocab#Concept> ;
                                                   
                                                   rdfs:subPropertyOf <http://id.nlm.nih.gov/mesh/vocab#broader> .
 
@@ -65,7 +66,7 @@
 
 <http://id.nlm.nih.gov/mesh/vocab#broaderDescriptor> rdf:type :ObjectProperty ;
                                                      
-                                                     <http://purl.org/dc/terms/description> "Relates 2 instances of the meshv:Descriptor class, one of which is broader than the other." ;
+                                                     dct:description "Relates 2 instances of the meshv:Descriptor class, one of which is broader than the other." ;
                                                      
                                                      rdfs:domain <http://id.nlm.nih.gov/mesh/vocab#Descriptor> ;
                                                      
@@ -91,7 +92,7 @@
 
 <http://id.nlm.nih.gov/mesh/vocab#concept> rdf:type :ObjectProperty ;
                                            
-                                           <http://purl.org/dc/terms/description> "Relates Descriptors, Qualifiers or SupplementaryConceptRecords to Concepts. Designates a member of a collection of Concepts for a Descriptor, Qualifier or SCR." .
+                                           dct:description "Relates Descriptors, Qualifiers or SupplementaryConceptRecords to Concepts. Designates a member of a collection of Concepts for a Descriptor, Qualifier or SCR." .
 
 
 
@@ -99,7 +100,7 @@
 
 <http://id.nlm.nih.gov/mesh/vocab#hasDescriptor> rdf:type :ObjectProperty ;
                                                  
-                                                 <http://purl.org/dc/terms/description> "Relates DescriptorQualifierPairs to Descriptors." ;
+                                                 dct:description "Relates DescriptorQualifierPairs to Descriptors." ;
                                                  
                                                  rdfs:range <http://id.nlm.nih.gov/mesh/vocab#Descriptor> .
 
@@ -109,7 +110,7 @@
 
 <http://id.nlm.nih.gov/mesh/vocab#hasQualifier> rdf:type :ObjectProperty ;
                                                 
-                                                <http://purl.org/dc/terms/description> "Relates DescriptorQualifierPairs to Qualifiers." ;
+                                                dct:description "Relates DescriptorQualifierPairs to Qualifiers." ;
                                                 
                                                 rdfs:range <http://id.nlm.nih.gov/mesh/vocab#Qualifier> .
 
@@ -119,7 +120,7 @@
 
 <http://id.nlm.nih.gov/mesh/vocab#indexerConsiderAlso> rdf:type :ObjectProperty ;
                                                        
-                                                       <http://purl.org/dc/terms/description> "Relates SupplementaryConceptRecords to Descriptors or DescriptorQualifierPairs. A Descriptor or DescriptorQualifierPair that is usually broader than the SupplementaryConceptRecord, and which is suggested as an indexing guideline for addition to the citation if pertinent to the article being indexed." .
+                                                       dct:description "Relates SupplementaryConceptRecords to Descriptors or DescriptorQualifierPairs. A Descriptor or DescriptorQualifierPair that is usually broader than the SupplementaryConceptRecord, and which is suggested as an indexing guideline for addition to the citation if pertinent to the article being indexed." .
 
 
 
@@ -127,7 +128,7 @@
 
 <http://id.nlm.nih.gov/mesh/vocab#mappedTo> rdf:type :ObjectProperty ;
                                             
-                                            <http://purl.org/dc/terms/description> "Relates SupplementaryConceptRecords to Descriptors or DescriptorQualifierPairs. A Descriptor or DescriptorQualifierPair that is a parent (not the main parent; lacks an asterisk designation in the Source XML) for the SupplementaryConceptRecord and that is automatically added to the journal citation for which the SupplementaryConceptRecord is indexed. See also meshv:preferredMappedTo." .
+                                            dct:description "Relates SupplementaryConceptRecords to Descriptors or DescriptorQualifierPairs. A Descriptor or DescriptorQualifierPair that is a parent (not the main parent; lacks an asterisk designation in the Source XML) for the SupplementaryConceptRecord and that is automatically added to the journal citation for which the SupplementaryConceptRecord is indexed. See also meshv:preferredMappedTo." .
 
 
 
@@ -135,7 +136,7 @@
 
 <http://id.nlm.nih.gov/mesh/vocab#narrowerConcept> rdf:type :ObjectProperty ;
                                                    
-                                                   <http://purl.org/dc/terms/description> "Relates 2 instances the of meshv:Concept class, one of which is narrower than the other." ;
+                                                   dct:description "Relates 2 instances the of meshv:Concept class, one of which is narrower than the other." ;
                                                    
                                                    rdfs:domain <http://id.nlm.nih.gov/mesh/vocab#Concept> ;
                                                    
@@ -148,7 +149,7 @@
 <http://id.nlm.nih.gov/mesh/vocab#parentTreeNumber> rdf:type :ObjectProperty ,
                                                              :TransitiveProperty ;
                                                     
-                                                    <http://purl.org/dc/terms/description> "Relates 2 instances of meshv:treeNumber classes, one of which is the immediate parent of the other." ;
+                                                    dct:description "Relates 2 instances of meshv:treeNumber classes, one of which is the immediate parent of the other." ;
                                                     
                                                     rdfs:range <http://id.nlm.nih.gov/mesh/vocab#TreeNumber> ;
                                                     
@@ -160,7 +161,7 @@
 
 <http://id.nlm.nih.gov/mesh/vocab#pharmacologicalAction> rdf:type :ObjectProperty ;
                                                          
-                                                         <http://purl.org/dc/terms/description> "Relates Descriptors or SupplementaryConceptRecords to Descriptors. Reference to a Descriptor describing observed biological activity of an exogenously administered chemical represented by a Descriptor or SupplementaryConceptRecord." .
+                                                         dct:description "Relates Descriptors or SupplementaryConceptRecords to Descriptors. Reference to a Descriptor describing observed biological activity of an exogenously administered chemical represented by a Descriptor or SupplementaryConceptRecord." .
 
 
 
@@ -168,7 +169,7 @@
 
 <http://id.nlm.nih.gov/mesh/vocab#preferredConcept> rdf:type :ObjectProperty ;
                                                     
-                                                    <http://purl.org/dc/terms/description> "Relates Descriptors or Supplementary Concept Records to Concepts. The preferred concept is frequently a broader concept that includes narrower sub-concepts, but may also be one among several distinct concepts. The preferred concept is selected as the primary or most prominent representation among the concepts in the literature. meshv:preferredConcept is a subproperty of meshv:concept." ;
+                                                    dct:description "Relates Descriptors or Supplementary Concept Records to Concepts. The preferred concept is frequently a broader concept that includes narrower sub-concepts, but may also be one among several distinct concepts. The preferred concept is selected as the primary or most prominent representation among the concepts in the literature. meshv:preferredConcept is a subproperty of meshv:concept." ;
                                                     
                                                     rdfs:subPropertyOf <http://id.nlm.nih.gov/mesh/vocab#concept> .
 
@@ -178,7 +179,7 @@
 
 <http://id.nlm.nih.gov/mesh/vocab#preferredMappedTo> rdf:type :ObjectProperty ;
                                                      
-                                                     <http://purl.org/dc/terms/description> "Relates SupplementaryConceptRecords to Descriptors or DescriptorQualifierPairs. Designates a Descriptor or DescriptorQualifierPair that is a main parent (includes an asterisk designation in the Source XML) for the SupplementaryConceptRecord and that is automatically added to the journal citation for which the SupplementaryConceptRecord is indexed. meshv:preferredMappedTo is a subproperty of meshv:mappedTo." ;
+                                                     dct:description "Relates SupplementaryConceptRecords to Descriptors or DescriptorQualifierPairs. Designates a Descriptor or DescriptorQualifierPair that is a main parent (includes an asterisk designation in the Source XML) for the SupplementaryConceptRecord and that is automatically added to the journal citation for which the SupplementaryConceptRecord is indexed. meshv:preferredMappedTo is a subproperty of meshv:mappedTo." ;
                                                      
                                                      rdfs:subPropertyOf <http://id.nlm.nih.gov/mesh/vocab#mappedTo> .
 
@@ -188,7 +189,7 @@
 
 <http://id.nlm.nih.gov/mesh/vocab#preferredTerm> rdf:type :ObjectProperty ;
                                                  
-                                                 <http://purl.org/dc/terms/description> "Relates Concepts to Terms. The Term in this relationship expresses the most relevant name of the Concept. meshv:preferredTerm is a subproperty of meshv:term." ;
+                                                 dct:description "Relates Concepts to Terms. The Term in this relationship expresses the most relevant name of the Concept. meshv:preferredTerm is a subproperty of meshv:term." ;
                                                  
                                                  rdfs:subPropertyOf <http://id.nlm.nih.gov/mesh/vocab#term> .
 
@@ -196,11 +197,7 @@
 
 ###  http://id.nlm.nih.gov/mesh/vocab#previousIndexing
 
-<http://id.nlm.nih.gov/mesh/vocab#previousIndexing> rdf:type :ObjectProperty ;
-                                                    
-                                                    rdfs:label "previousIndexing" ;
-                                                    
-                                                    <http://purl.org/dc/terms/description> "A property of Descriptors and Supplementary Concept Records. Free-text information referring to Descriptors or DescriptorQualifierPairs that were used to index the concept in MEDLINE before the Descriptor was created. Intended to enable users of new Descriptors to find similar concepts indexed before the Descriptor was created. Includes a date or date range. May include descriptive text referring to a group of Descriptors as “specifics”. Data are not maintained when a Descriptor or Qualifier name changes. DUI D005290 example: Iron (1966-1974). Also used for SupplementaryConceptRecords to refer to the Descriptor or DescriptorQualifierPair to which the SupplementaryConceptRecord was previously mapped." .
+<http://id.nlm.nih.gov/mesh/vocab#previousIndexing> rdf:type :ObjectProperty .
 
 
 
@@ -208,7 +205,7 @@
 
 <http://id.nlm.nih.gov/mesh/vocab#recordPreferredTerm> rdf:type :ObjectProperty ;
                                                        
-                                                       <http://purl.org/dc/terms/description> "Relates Descriptors, Qualifiers or SupplementaryConceptRecords to Terms. Indicates that the Term is the preferred term for a Descriptor, Qualifier, or SupplementaryConceptRecord." .
+                                                       dct:description "Relates Descriptors, Qualifiers or SupplementaryConceptRecords to Terms. Indicates that the Term is the preferred term for a Descriptor, Qualifier, or SupplementaryConceptRecord." .
 
 
 
@@ -216,7 +213,7 @@
 
 <http://id.nlm.nih.gov/mesh/vocab#relatedConcept> rdf:type :ObjectProperty ;
                                                   
-                                                  <http://purl.org/dc/terms/description> "Relates one Concept to another. A semantic relationship between two Concepts, usually between the preferred Concept and subordinate Concept(s) where one is neither broader nor narrower in meaning." ;
+                                                  dct:description "Relates one Concept to another. A semantic relationship between two Concepts, usually between the preferred Concept and subordinate Concept(s) where one is neither broader nor narrower in meaning." ;
                                                   
                                                   rdfs:range <http://id.nlm.nih.gov/mesh/vocab#Concept> ;
                                                   
@@ -228,7 +225,7 @@
 
 <http://id.nlm.nih.gov/mesh/vocab#seeAlso> rdf:type :ObjectProperty ;
                                            
-                                           <http://purl.org/dc/terms/description> "Relates one Descriptor to another. Reference to a specific Descriptor to which a user is referred by a 'see related' cross-reference." .
+                                           dct:description "Relates one Descriptor to another. Reference to a specific Descriptor to which a user is referred by a 'see related' cross-reference." .
 
 
 
@@ -236,7 +233,7 @@
 
 <http://id.nlm.nih.gov/mesh/vocab#term> rdf:type :ObjectProperty ;
                                         
-                                        <http://purl.org/dc/terms/description> "Relates Concepts to Terms. Each Concept has a set of entry terms and a preferred term that are related to the Concept." .
+                                        dct:description "Relates Concepts to Terms. Each Concept has a set of entry terms and a preferred term that are related to the Concept." .
 
 
 
@@ -244,7 +241,7 @@
 
 <http://id.nlm.nih.gov/mesh/vocab#treeNumber> rdf:type :ObjectProperty ;
                                               
-                                              <http://purl.org/dc/terms/description> "Relates Descriptors or Qualifiers to TreeNumbers. Alpha-numeric string referring to location within a Descriptor or Qualifier hierarchy. Used for browsing the MeSH vocabulary and for inclusive searches by retrieval systems using MeSH. (Note that the Trees hierarchy is not represented using subelements. The hierarchy is represented by the TreeNumber itself.) Up to thirteen hierarchical levels." ;
+                                              dct:description "Relates Descriptors or Qualifiers to TreeNumbers. Alpha-numeric string referring to location within a Descriptor or Qualifier hierarchy. Used for browsing the MeSH vocabulary and for inclusive searches by retrieval systems using MeSH. (Note that the Trees hierarchy is not represented using subelements. The hierarchy is represented by the TreeNumber itself.) Up to thirteen hierarchical levels." ;
                                               
                                               rdfs:range <http://id.nlm.nih.gov/mesh/vocab#TreeNumber> .
 
@@ -254,7 +251,7 @@
 
 <http://id.nlm.nih.gov/mesh/vocab#useInstead> rdf:type :ObjectProperty ;
                                               
-                                              <http://purl.org/dc/terms/description> "Relates DisallowedDescriptorQualifierPairs to Descriptors or AllowedDescriptorQualifierPairs. Descriptor or DescriptorQualifierPair recommended in place of the prohibited combination." .
+                                              dct:description "Relates DisallowedDescriptorQualifierPairs to Descriptors or AllowedDescriptorQualifierPairs. Descriptor or DescriptorQualifierPair recommended in place of the prohibited combination." .
 
 
 
@@ -273,7 +270,7 @@
                                                 
                                                 rdfs:label "abbreviation" ;
                                                 
-                                                <http://purl.org/dc/terms/description> "A property of Terms. Two-letter, uppercase abbreviation for a Qualifier term." .
+                                                dct:description "A property of Terms. Two-letter, uppercase abbreviation for a Qualifier term." .
 
 
 
@@ -283,7 +280,7 @@
                                             
                                             rdfs:label "altLabel" ;
                                             
-                                            <http://purl.org/dc/terms/description> "A property of Terms. A lexical variant for a Term’s prefLabel. meshv:altLabel is a subproperty of rdfs:label" ;
+                                            dct:description "A property of Terms. A lexical variant for a Term’s prefLabel. meshv:altLabel is a subproperty of rdfs:label" ;
                                             
                                             :propertyDisjointWith <http://id.nlm.nih.gov/mesh/vocab#prefLabel> ;
                                             
@@ -297,7 +294,7 @@
                                               
                                               rdfs:label "annotation" ;
                                               
-                                              <http://purl.org/dc/terms/description> "A property of Descriptors or Qualifiers. Free-text information for indexers and catalogers concerning the use of the Descriptor or Qualifier." .
+                                              dct:description "A property of Descriptors or Qualifiers. Free-text information for indexers and catalogers concerning the use of the Descriptor or Qualifier." .
 
 
 
@@ -307,7 +304,7 @@
                                                
                                                rdfs:label "casn1_label" ;
                                                
-                                               <http://purl.org/dc/terms/description> "A property of Concepts. Free-text of the Chemical Abstracts Type N1 Name which is the systematic name used in the Chemical Abstracts Chemical Substance and Formula Indexes. The systematic name is a unique name assigned to a chemical substance to represent its structure. First available in 1995." .
+                                               dct:description "A property of Concepts. Free-text of the Chemical Abstracts Type N1 Name which is the systematic name used in the Chemical Abstracts Chemical Substance and Formula Indexes. The systematic name is a unique name assigned to a chemical substance to represent its structure. First available in 1995." .
 
 
 
@@ -317,7 +314,7 @@
                                                 
                                                 rdfs:label "considerAlso" ;
                                                 
-                                                <http://purl.org/dc/terms/description> "A property of Descriptors. Free-text information that refers a user from a Descriptor to other terms which have related roots." .
+                                                dct:description "A property of Descriptors. Free-text information that refers a user from a Descriptor to other terms which have related roots." .
 
 
 
@@ -327,7 +324,7 @@
                                                
                                                rdfs:label "dateCreated" ;
                                                
-                                               <http://purl.org/dc/terms/description> "A property of Descriptors, Qualifiers, SupplementaryConceptRecords or Terms. Date in YYYY-MM-DD format when a Descriptor, Qualifer, SupplementaryConceptRecord or Term was first added to MeSH provisionally. This timestamp may be a year behind the dateEstablished. Upon conversion to a new MeSH maintenance system in 1999, a default value of 1999-01-01 was supplied." .
+                                               dct:description "A property of Descriptors, Qualifiers, SupplementaryConceptRecords or Terms. Date in YYYY-MM-DD format when a Descriptor, Qualifer, SupplementaryConceptRecord or Term was first added to MeSH provisionally. This timestamp may be a year behind the dateEstablished. Upon conversion to a new MeSH maintenance system in 1999, a default value of 1999-01-01 was supplied." .
 
 
 
@@ -337,7 +334,7 @@
                                                    
                                                    rdfs:label "dateEstablished" ;
                                                    
-                                                   <http://purl.org/dc/terms/description> "A property of Descriptors or Qualifiers. Date in YYYY-MM-DD format when the Descriptor or Qualifier became effective for use; set to YYYY-01-01 where YYYY = year of introduction to MeSH." .
+                                                   dct:description "A property of Descriptors or Qualifiers. Date in YYYY-MM-DD format when the Descriptor or Qualifier became effective for use; set to YYYY-01-01 where YYYY = year of introduction to MeSH." .
 
 
 
@@ -347,7 +344,7 @@
                                                
                                                rdfs:label "dateRevised" ;
                                                
-                                               <http://purl.org/dc/terms/description> "A property of Descriptors, Qualifiers, or SupplementaryConceptRecords. Indicates that a revision was made to Descriptor, Qualifier, or SupplementaryConceptRecord data in YYYY-MM-DD format." .
+                                               dct:description "A property of Descriptors, Qualifiers, or SupplementaryConceptRecords. Indicates that a revision was made to Descriptor, Qualifier, or SupplementaryConceptRecord data in YYYY-MM-DD format." .
 
 
 
@@ -357,7 +354,7 @@
                                                 
                                                 rdfs:label "entryVersion" ;
                                                 
-                                                <http://purl.org/dc/terms/description> "A property of Terms. Used for internal NLM processing only." .
+                                                dct:description "A property of Terms. Used for internal NLM processing only." .
 
 
 
@@ -367,7 +364,7 @@
                                              
                                              rdfs:label "frequency" ;
                                              
-                                             <http://purl.org/dc/terms/description> "A property of SupplementaryConceptRecords. Number of citations indexed with a SupplementaryConceptRecord in MEDLINE/PubMed. Automatically updated monthly in the XML. See also meshv:source definition." .
+                                             dct:description "A property of SupplementaryConceptRecords. Number of citations indexed with a SupplementaryConceptRecord in MEDLINE/PubMed. Automatically updated monthly in the XML. See also meshv:source definition." .
 
 
 
@@ -377,7 +374,7 @@
                                                
                                                rdfs:label "historyNote" ;
                                                
-                                               <http://purl.org/dc/terms/description> "A property of Descriptors or Qualifiers. Free-text information that traces the concept in MeSH and is deemed helpful for the online searcher. Headings and entry terms are entered in upper case. Initial characters refer to the year in which the Descriptor or Qualifier was created in MeSH in its current form (i.e., with the same preferred term). A date in parentheses indicates the oldest creation date of terms, provisional headings (before 1975), or minor headings (before 1991), which are reflected in bibliographic citations. Entries without a year date were created between 1963 and 1966." .
+                                               dct:description "A property of Descriptors or Qualifiers. Free-text information that traces the concept in MeSH and is deemed helpful for the online searcher. Headings and entry terms are entered in upper case. Initial characters refer to the year in which the Descriptor or Qualifier was created in MeSH in its current form (i.e., with the same preferred term). A date in parentheses indicates the oldest creation date of terms, provisional headings (before 1975), or minor headings (before 1991), which are reflected in bibliographic citations. Entries without a year date were created between 1963 and 1966." .
 
 
 
@@ -387,7 +384,7 @@
                                               
                                               rdfs:label "identifier" ;
                                               
-                                              <http://purl.org/dc/terms/description> "A property of Descriptors, Qualifiers, SupplementaryConceptRecords, Concepts, Terms and SemanticTypes. Descriptor identifier is a 7 or 10 alphanumeric starting with the letter D. Qualifier identifier is a 7 or 10 alphanumeric starting with the letter Q. SupplementaryConceptRecord identifier is a 7 or 10 alphanumeric starting with the letter C. Concept identifier is an 8 or 10 alphanumeric starting with the letter M. Term identifier is a 7 or 10 alphanumeric starting with the letter T. The 10 alphanumeric format was implemented for new identifiers created on or after about May 19, 2014." .
+                                              dct:description "A property of Descriptors, Qualifiers, SupplementaryConceptRecords, Concepts, Terms and SemanticTypes. Descriptor identifier is a 7 or 10 alphanumeric starting with the letter D. Qualifier identifier is a 7 or 10 alphanumeric starting with the letter Q. SupplementaryConceptRecord identifier is a 7 or 10 alphanumeric starting with the letter C. Concept identifier is an 8 or 10 alphanumeric starting with the letter M. Term identifier is a 7 or 10 alphanumeric starting with the letter T. The 10 alphanumeric format was implemented for new identifiers created on or after about May 19, 2014." .
 
 
 
@@ -397,7 +394,7 @@
                                               
                                               rdfs:label "lexicalTag" ;
                                               
-                                              <http://purl.org/dc/terms/description> "A property of Terms. A 3-letter value that indicates the lexical category. Valid values with their meanings in parentheses are: ABB (Abbreviation); ABX (Embedded abbreviation); ACR (Acronym); ACX (Embedded acronym); EPO (Eponym); LAB (Lab number); NAM (Proper name); NON (None); and TRD (Trade name). Note that in the XML, a Permuted Term will always have the same Lexical Tag value as the term from which it is generated." .
+                                              dct:description "A property of Terms. A 3-letter value that indicates the lexical category. Valid values with their meanings in parentheses are: ABB (Abbreviation); ABX (Embedded abbreviation); ACR (Acronym); ACX (Embedded acronym); EPO (Eponym); LAB (Lab number); NAM (Proper name); NON (None); and TRD (Trade name). Note that in the XML, a Permuted Term will always have the same Lexical Tag value as the term from which it is generated." .
 
 
 
@@ -407,7 +404,7 @@
                                         
                                         rdfs:label "note" ;
                                         
-                                        <http://purl.org/dc/terms/description> "A property of SupplementaryConceptRecords. Free-text narrative giving information about the SupplementaryConceptRecord, and may include information such as the registryNumber." .
+                                        dct:description "A property of SupplementaryConceptRecords. Free-text narrative giving information about the SupplementaryConceptRecord, and may include information such as the registryNumber." .
 
 
 
@@ -417,7 +414,7 @@
                                               
                                               rdfs:label "onlineNote" ;
                                               
-                                              <http://purl.org/dc/terms/description> "A property of Descriptors and Qualifiers. Free-text information intended to direct the MeSH online searcher to alternate search terms. Superseded by a more detailed historyNote when onlineNote is not present." .
+                                              dct:description "A property of Descriptors and Qualifiers. Free-text information intended to direct the MeSH online searcher to alternate search terms. Superseded by a more detailed historyNote when onlineNote is not present." .
 
 
 
@@ -427,7 +424,7 @@
                                              
                                              rdfs:label "prefLabel" ;
                                              
-                                             <http://purl.org/dc/terms/description> "A property of Terms. The preferred string for the term. meshv:prefLabel is a subproperty of rdfs:label." ;
+                                             dct:description "A property of Terms. The preferred string for the term. meshv:prefLabel is a subproperty of rdfs:label." ;
                                              
                                              rdfs:subPropertyOf rdfs:label .
 
@@ -435,11 +432,7 @@
 
 ###  http://id.nlm.nih.gov/mesh/vocab#previousIndexing
 
-<http://id.nlm.nih.gov/mesh/vocab#previousIndexing> rdf:type :DatatypeProperty ;
-                                                    
-                                                    rdfs:label "previousIndexing" ;
-                                                    
-                                                    <http://purl.org/dc/terms/description> "A property of Descriptors and Supplementary Concept Records. Free-text information referring to Descriptors or DescriptorQualifierPairs that were used to index the concept in MEDLINE before the Descriptor was created. Intended to enable users of new Descriptors to find similar concepts indexed before the Descriptor was created. Includes a date or date range. May include descriptive text referring to a group of Descriptors as “specifics”. Data are not maintained when a Descriptor or Qualifier name changes. DUI D005290 example: Iron (1966-1974). Also used for SupplementaryConceptRecords to refer to the Descriptor or DescriptorQualifierPair to which the SupplementaryConceptRecord was previously mapped." .
+<http://id.nlm.nih.gov/mesh/vocab#previousIndexing> rdf:type :DatatypeProperty .
 
 
 
@@ -449,7 +442,7 @@
                                                   
                                                   rdfs:label "publicMeSHNote" ;
                                                   
-                                                  <http://purl.org/dc/terms/description> "A property of Descriptors. Free-text information about the history of changes to the Descriptor that may be helpful to the user of the printed Index Medicus publication (ceased in 2005). This includes the date the Descriptor was created in MeSH, changes in the preferred term, earlier status as an SupplementaryConceptRecord, etc. Unlike the History Note, this note reflects the MeSH vocabulary printed at that point in time, not as updated for online databases. Applies only to TopicalDescriptors. MeSH Descriptor labels are in upper case." .
+                                                  dct:description "A property of Descriptors. Free-text information about the history of changes to the Descriptor that may be helpful to the user of the printed Index Medicus publication (ceased in 2005). This includes the date the Descriptor was created in MeSH, changes in the preferred term, earlier status as an SupplementaryConceptRecord, etc. Unlike the History Note, this note reflects the MeSH vocabulary printed at that point in time, not as updated for online databases. Applies only to TopicalDescriptors. MeSH Descriptor labels are in upper case." .
 
 
 
@@ -459,7 +452,7 @@
                                                   
                                                   rdfs:label "registryNumber" ;
                                                   
-                                                  <http://purl.org/dc/terms/description> "A property of Concepts. A unique identifier from one of these sources: Enzyme Commission (Example: EC 2.4.2.17; Example for Partial enzyme number: EC 1.4.3.-); Chemical Abstracts Service (CAS) (Example: 7004-12-8); FDA Substance Registration System Unique Identifier (UNII) in 10-character format (Example: R16CO5Y76E); or the value of 0 if no match is available from the previous sources. A single MeSH Concept can only have one Registry Number. Used for Concepts related to Descriptors in the D Category Drugs and Chemicals and for SupplementaryConceptRecords." .
+                                                  dct:description "A property of Concepts. A unique identifier from one of these sources: Enzyme Commission (Example: EC 2.4.2.17; Example for Partial enzyme number: EC 1.4.3.-); Chemical Abstracts Service (CAS) (Example: 7004-12-8); FDA Substance Registration System Unique Identifier (UNII) in 10-character format (Example: R16CO5Y76E); or the value of 0 if no match is available from the previous sources. A single MeSH Concept can only have one Registry Number. Used for Concepts related to Descriptors in the D Category Drugs and Chemicals and for SupplementaryConceptRecords." .
 
 
 
@@ -469,7 +462,7 @@
                                                          
                                                          rdfs:label "relatedRegistryNumber" ;
                                                          
-                                                         <http://purl.org/dc/terms/description> "A property of Concepts. An additional unique identifier for chemicals, which is sometimes followed by a label in parentheses. Multiple Related Registry Numbers are allowed for each Concept. For example, these might be salts and/or stereoisomers of the parent compound. Used for Concepts related to Descriptors in the D Category Drugs and Chemicals and for SupplementaryConceptRecords." .
+                                                         dct:description "A property of Concepts. An additional unique identifier for chemicals, which is sometimes followed by a label in parentheses. Multiple Related Registry Numbers are allowed for each Concept. For example, these might be salts and/or stereoisomers of the parent compound. Used for Concepts related to Descriptors in the D Category Drugs and Chemicals and for SupplementaryConceptRecords." .
 
 
 
@@ -479,7 +472,7 @@
                                              
                                              rdfs:label "scopeNote" ;
                                              
-                                             <http://purl.org/dc/terms/description> "A property of Concepts. Free-text narrative giving the scope and meaning (definition) of a Concept." .
+                                             dct:description "A property of Concepts. Free-text narrative giving the scope and meaning (definition) of a Concept." .
 
 
 
@@ -489,7 +482,7 @@
                                                
                                                rdfs:label "sortVersion" ;
                                                
-                                               <http://purl.org/dc/terms/description> "A property of Terms. Custom version of a Term label used to sort properly in a print product; format is all uppercase." .
+                                               dct:description "A property of Terms. Custom version of a Term label used to sort properly in a print product; format is all uppercase." .
 
 
 
@@ -499,7 +492,7 @@
                                           
                                           rdfs:label "source" ;
                                           
-                                          <http://purl.org/dc/terms/description> "A property of SupplementaryConceptRecords. Citation reference string in which the SupplementaryConceptRecord was first found. Single occurrence if SupplementaryConceptRecord created since 1980; frequency reports total citations indexed with the term in MEDLINE/PubMed. Possible multiple occurrences if SupplementaryConceptRecord created prior to 1980; term not found on those citations in MEDLINE/PubMed. Number of multiple Source occurrences need to be added to Frequency count for grand total of citations to articles discussing the SCR." .
+                                          dct:description "A property of SupplementaryConceptRecords. Citation reference string in which the SupplementaryConceptRecord was first found. Single occurrence if SupplementaryConceptRecord created since 1980; frequency reports total citations indexed with the term in MEDLINE/PubMed. Possible multiple occurrences if SupplementaryConceptRecord created prior to 1980; term not found on those citations in MEDLINE/PubMed. Number of multiple Source occurrences need to be added to Frequency count for grand total of citations to articles discussing the SCR." .
 
 
 
@@ -507,8 +500,8 @@
 
 <http://id.nlm.nih.gov/mesh/vocab#thesaurusID> rdf:type :DatatypeProperty ;
                                                
-                                               <http://purl.org/dc/terms/description> "thesaurusID" ,
-                                                                                      "A property of Terms. Name of a Thesaurus in which the term occurs. The value 'NLM' is equivalent to MeSH." .
+                                               dct:description "A property of Terms. Name of a Thesaurus in which the term occurs. The value 'NLM' is equivalent to MeSH." ,
+                                                               "thesaurusID" .
 
 
 
@@ -537,7 +530,7 @@ rdfs:label rdf:type :DatatypeProperty .
                                                                   
                                                                   :disjointWith <http://id.nlm.nih.gov/mesh/vocab#DisallowedDescriptorQualifierPair> ;
                                                                   
-                                                                  <http://purl.org/dc/terms/description> "A combined MeSH descriptor and qualifier, where the pairing is allowed by MeSH rules. These URIs are a mash up of the descriptor and qualifier identifiers, such as D000236Q000235." .
+                                                                  dct:description "A combined MeSH descriptor and qualifier, where the pairing is allowed by MeSH rules. These URIs are a mash up of the descriptor and qualifier identifiers, such as D000236Q000235." .
 
 
 
@@ -553,7 +546,7 @@ rdfs:label rdf:type :DatatypeProperty .
                                                           <http://id.nlm.nih.gov/mesh/vocab#PublicationType> ,
                                                           <http://id.nlm.nih.gov/mesh/vocab#TopicalDescriptor> ;
                                             
-                                            <http://purl.org/dc/terms/description> "A special class of descriptor singled out because they are so frequently applied to biomedical literature. There are only 2 Descriptors that are members of the class meshv:CheckTag: D005260 (Male) and D008297 (Female). These two Descriptors do not have tree numbers. " .
+                                            dct:description "A special class of descriptor singled out because they are so frequently applied to biomedical literature. There are only 2 Descriptors that are members of the class meshv:CheckTag: D005260 (Male) and D008297 (Female). These two Descriptors do not have tree numbers. " .
 
 
 
@@ -572,7 +565,7 @@ rdfs:label rdf:type :DatatypeProperty .
                                                          <http://id.nlm.nih.gov/mesh/vocab#Term> ,
                                                          <http://id.nlm.nih.gov/mesh/vocab#TreeNumber> ;
                                            
-                                           <http://purl.org/dc/terms/description> "MeSH concepts are meanings. Many MeSH concepts contain synonymous terms. meshv:Concept identifiers begin with 'M' such as M0000013,  'Congenital Abnormalities'." .
+                                           dct:description "MeSH concepts are meanings. Many MeSH concepts contain synonymous terms. meshv:Concept identifiers begin with 'M' such as M0000013,  'Congenital Abnormalities'." .
 
 
 
@@ -590,7 +583,7 @@ rdfs:label rdf:type :DatatypeProperty .
                                                             <http://id.nlm.nih.gov/mesh/vocab#Term> ,
                                                             <http://id.nlm.nih.gov/mesh/vocab#TreeNumber> ;
                                               
-                                              <http://purl.org/dc/terms/description> "MeSH Descriptors are a cluster of one or more concepts used to describe what a publication is about. meshv:Descriptor is the parent class of meshv:TopicalDescriptor, meshv:GeographicDescriptor, meshv:PublicationType, and meshv:CheckTag." .
+                                              dct:description "MeSH Descriptors are a cluster of one or more concepts used to describe what a publication is about. meshv:Descriptor is the parent class of meshv:TopicalDescriptor, meshv:GeographicDescriptor, meshv:PublicationType, and meshv:CheckTag." .
 
 
 
@@ -607,7 +600,7 @@ rdfs:label rdf:type :DatatypeProperty .
                                                                          <http://id.nlm.nih.gov/mesh/vocab#Term> ,
                                                                          <http://id.nlm.nih.gov/mesh/vocab#TreeNumber> ;
                                                            
-                                                           <http://purl.org/dc/terms/description> "A combined MeSH descriptor and qualifier pair. Allowed pairs (according to MeSH rules) belong to the class meshv:AllowedDescriptorQualifierPair. Disallowed pairs belong to the class meshv:DisallowedDescriptorQualifierPair." .
+                                                           dct:description "A combined MeSH descriptor and qualifier pair. Allowed pairs (according to MeSH rules) belong to the class meshv:AllowedDescriptorQualifierPair. Disallowed pairs belong to the class meshv:DisallowedDescriptorQualifierPair." .
 
 
 
@@ -619,7 +612,7 @@ rdfs:label rdf:type :DatatypeProperty .
                                                                      
                                                                      rdfs:subClassOf <http://id.nlm.nih.gov/mesh/vocab#DescriptorQualifierPair> ;
                                                                      
-                                                                     <http://purl.org/dc/terms/description> "A combined MeSH descriptor and qualifier where the pairing is not allowed by MeSH rules, such as Abdomen/radiography." .
+                                                                     dct:description "A combined MeSH descriptor and qualifier where the pairing is not allowed by MeSH rules, such as Abdomen/radiography." .
 
 
 
@@ -634,7 +627,7 @@ rdfs:label rdf:type :DatatypeProperty .
                                                           :disjointWith <http://id.nlm.nih.gov/mesh/vocab#PublicationType> ,
                                                                         <http://id.nlm.nih.gov/mesh/vocab#TopicalDescriptor> ;
                                                           
-                                                          <http://purl.org/dc/terms/description> "A descriptor that references places or regions of the world, such as D001061, 'Appalachian Region'." .
+                                                          dct:description "A descriptor that references places or regions of the world, such as D001061, 'Appalachian Region'." .
 
 
 
@@ -648,7 +641,7 @@ rdfs:label rdf:type :DatatypeProperty .
                                                    
                                                    :disjointWith <http://id.nlm.nih.gov/mesh/vocab#TopicalDescriptor> ;
                                                    
-                                                   <http://purl.org/dc/terms/description> "A special class of descriptor that describes what type of publication a resource is as opposed to what it is about. All MeSH Publication Types are in the V tree." .
+                                                   dct:description "A special class of descriptor that describes what type of publication a resource is as opposed to what it is about. All MeSH Publication Types are in the V tree." .
 
 
 
@@ -664,7 +657,7 @@ rdfs:label rdf:type :DatatypeProperty .
                                                            <http://id.nlm.nih.gov/mesh/vocab#Term> ,
                                                            <http://id.nlm.nih.gov/mesh/vocab#TreeNumber> ;
                                              
-                                             <http://purl.org/dc/terms/description> "Also known as Subheadings, these provide context to the use of a MeSH Heading." .
+                                             dct:description "Also known as Subheadings, these provide context to the use of a MeSH Heading." .
 
 
 
@@ -679,7 +672,7 @@ rdfs:label rdf:type :DatatypeProperty .
                                                 :disjointWith <http://id.nlm.nih.gov/mesh/vocab#SCR_Disease> ,
                                                               <http://id.nlm.nih.gov/mesh/vocab#SCR_Protocol> ;
                                                 
-                                                <http://purl.org/dc/terms/description> "These are chemicals, drugs, enzymes, vitamins, etc." .
+                                                dct:description "These are chemicals, drugs, enzymes, vitamins, etc." .
 
 
 
@@ -693,7 +686,7 @@ rdfs:label rdf:type :DatatypeProperty .
                                                
                                                :disjointWith <http://id.nlm.nih.gov/mesh/vocab#SCR_Protocol> ;
                                                
-                                               <http://purl.org/dc/terms/description> "SCR Diseases were originally brought into MeSH from a list maintained by the Office of Rare Diseases Research." .
+                                               dct:description "SCR Diseases were originally brought into MeSH from a list maintained by the Office of Rare Diseases Research." .
 
 
 
@@ -705,7 +698,7 @@ rdfs:label rdf:type :DatatypeProperty .
                                                 
                                                 rdfs:subClassOf <http://id.nlm.nih.gov/mesh/vocab#SupplementaryConceptRecord> ;
                                                 
-                                                <http://purl.org/dc/terms/description> "MeSH protocols are therapies in the domain of cancer treatment." .
+                                                dct:description "MeSH protocols are therapies in the domain of cancer treatment." .
 
 
 
@@ -720,7 +713,7 @@ rdfs:label rdf:type :DatatypeProperty .
                                                               :disjointWith <http://id.nlm.nih.gov/mesh/vocab#Term> ,
                                                                             <http://id.nlm.nih.gov/mesh/vocab#TreeNumber> ;
                                                               
-                                                              <http://purl.org/dc/terms/description> "Supplementary Concepts are created in MeSH to aid in searching the large volume of mainly chemicals and drugs. meshv:SupplementaryConceptRecord has three sub-classes: meshv:RegularSubstance, meshv:SCR_Protocol, and meshv:SCR_Disease." .
+                                                              dct:description "Supplementary Concepts are created in MeSH to aid in searching the large volume of mainly chemicals and drugs. meshv:SupplementaryConceptRecord has three sub-classes: meshv:RegularSubstance, meshv:SCR_Protocol, and meshv:SCR_Disease." .
 
 
 
@@ -734,7 +727,7 @@ rdfs:label rdf:type :DatatypeProperty .
                                         
                                         :disjointWith <http://id.nlm.nih.gov/mesh/vocab#TreeNumber> ;
                                         
-                                        <http://purl.org/dc/terms/description> "MeSH terms provide synonymous names for MeSH concepts. Terms have 'T' identifiers, and are considered either preferred or lexical variants, such as 'Congenital Abnormalities' as opposed to 'Abnormality, Congenital'." .
+                                        dct:description "MeSH terms provide synonymous names for MeSH concepts. Terms have 'T' identifiers, and are considered either preferred or lexical variants, such as 'Congenital Abnormalities' as opposed to 'Abnormality, Congenital'." .
 
 
 
@@ -746,7 +739,7 @@ rdfs:label rdf:type :DatatypeProperty .
                                                      
                                                      rdfs:subClassOf <http://id.nlm.nih.gov/mesh/vocab#Descriptor> ;
                                                      
-                                                     <http://purl.org/dc/terms/description> "Topical Descriptors indicate the subject of an indexed item such as a journal article. See D063926, 'Drug Hypersensitivity Syndrome', for an example." .
+                                                     dct:description "Topical Descriptors indicate the subject of an indexed item such as a journal article. See D063926, 'Drug Hypersensitivity Syndrome', for an example." .
 
 
 
@@ -758,7 +751,7 @@ rdfs:label rdf:type :DatatypeProperty .
                                               
                                               rdfs:subClassOf :Thing ;
                                               
-                                              <http://purl.org/dc/terms/description> "Tree Numbers are used to organize MeSH Descriptors in a broader-than/narrower-than manner." .
+                                              dct:description "Tree Numbers are used to organize MeSH Descriptors in a broader-than/narrower-than manner." .
 
 
 
@@ -769,5 +762,20 @@ rdfs:label rdf:type :DatatypeProperty .
 
 
 
-###  Generated by the OWL API (version 3.5.0) http://owlapi.sourceforge.net
+
+#################################################################
+#
+#    Annotations
+#
+#################################################################
+
+
+<http://id.nlm.nih.gov/mesh/vocab#previousIndexing> rdfs:label "previousIndexing" ;
+                                                    
+                                                    dct:description "A property of Descriptors and Supplementary Concept Records. Free-text information referring to Descriptors or DescriptorQualifierPairs that were used to index the concept in MEDLINE before the Descriptor was created. Intended to enable users of new Descriptors to find similar concepts indexed before the Descriptor was created. Includes a date or date range. May include descriptive text referring to a group of Descriptors as “specifics”. Data are not maintained when a Descriptor or Qualifier name changes. DUI D005290 example: Iron (1966-1974). Also used for SupplementaryConceptRecords to refer to the Descriptor or DescriptorQualifierPair to which the SupplementaryConceptRecord was previously mapped." .
+
+
+
+
+###  Generated by the OWL API (version 3.5.1) http://owlapi.sourceforge.net
 


### PR DESCRIPTION
@stevenemrick , I added the "dct" prefix, so that all your annotations use it.  I don't know why Protege moved previousIndexing to the end, but I guess it doesn't hurt anything.