### PR TITLE
Get vocabulary and void version and setup hardlinks

### DIFF
--- a/bin/mesh-xml2rdf.sh
+++ b/bin/mesh-xml2rdf.sh
@@ -81,3 +81,19 @@ fi
 cp $MESHRDF_HOME/meta/vocabulary.ttl $OUTDIR
 cp $MESHRDF_HOME/meta/void.ttl $OUTDIR
 
+cd $OUTDIR
+
+vocab_version=`awk '$1~/versionInfo/ { gsub(/"/, "", $2); print $2 }' vocabulary.ttl`
+if [ -z "$vocab_version" ]; then 
+    echo "Unable to determine vocabulary.ttl version" 1>&2
+    exit 1
+fi
+
+void_version=`awk '$1~/versionInfo/ { gsub(/"/, "", $2); print $2 }' void.ttl`
+if [ -z "$void_version" ]; then 
+    echo "Unable to determine void.ttl version" 1>&2
+fi
+
+ln -f void.ttl void_$vocab_version.ttl
+ln -f vocabulary.ttl vocabulary_$vocab_version.ttl
+


### PR DESCRIPTION
As a sub-part of issues #144 and #147, update bin/mesh-xml2rdf.sh to do the following:
 - Get the version of the vocabulary.ttl and void.ttl files.
 - Create hard link for the versioned files.