### PR TITLE
Fix HHS/mesh-rdf#190 by copying the service_description.ttl properly.

### DIFF
--- a/bin/mesh-xml2rdf.sh
+++ b/bin/mesh-xml2rdf.sh
@@ -104,7 +104,7 @@ fi
 # Copy the meta files
 cp meta/vocabulary.ttl $OUTDIR
 cp meta/void.ttl $OUTDIR
-cp /meta/service_description.ttl $OUTDIR
+cp meta/service_description.ttl $OUTDIR
 
 # Set up hard links to version-specific vocabulary and void 
 cd $OUTDIR


### PR DESCRIPTION
- The script that loads the triple store relies on this file to load the service description properly.
- The script that loads the triple store also clears virtuoso's own service description as we are not offering a sparql endpoint at localhost:8890.