### PR TITLE
Update scripts for MeSH 2016

### DIFF
--- a/bin/fetch-mesh-xml.sh
+++ b/bin/fetch-mesh-xml.sh
@@ -1,4 +1,15 @@
-#!/bin/sh -e
+#!/bin/bash 
+
+
+while getopts "h:y:u:" opt; do
+    case $opt in 
+        h) export MESHRDF_HOME=$OPTARG ;;
+        y) export MESHRDF_YEAR=$OPTARG ;;
+        u) export MESHRDF_URI=$OPTARG ;;
+        *) echo "Usage: $0 [-h meshrdf-home] [-y year] [-u uri] [-i]" 1>&2 ; exit 1 ;;
+    esac
+done
+shift $(($OPTIND - 1))
 
 if [ -z "$MESHRDF_HOME" ]; then
     echo "Please define MESHRDF_HOME environment variable" 1>&2
@@ -13,13 +24,13 @@ YEAR=${MESHRDF_YEAR:-2015}
 # Can override default URI with MESHRDF_URI environment variable
 URI=${MESHRDF_URI:-ftp://ftp.nlm.nih.gov/online/mesh/$YEAR}
 
-wget "$URI/desc$YEAR.dtd" -O "$MESHRDF_HOME/data/desc$YEAR.dtd"
 wget "$URI/desc$YEAR.xml" -O "$MESHRDF_HOME/data/desc$YEAR.xml"
-wget "$URI/pa$YEAR.dtd" -O "$MESHRDF_HOME/data/pa$YEAR.dtd"
-wget "$URI/pa$YEAR.xml" -O "$MESHRDF_HOME/data/pa$YEAR.xml"
-wget "$URI/qual$YEAR.dtd" -O "$MESHRDF_HOME/data/qual$YEAR.dtd"
 wget "$URI/qual$YEAR.xml" -O "$MESHRDF_HOME/data/qual$YEAR.xml"
-wget "$URI/supp$YEAR.dtd" -O "$MESHRDF_HOME/data/supp$YEAR.dtd"
 wget "$URI/supp$YEAR.xml" -O "$MESHRDF_HOME/data/supp$YEAR.xml"
 
+if [ $YEAR -le 2015 ]; then
+    wget "$URI/desc$YEAR.dtd" -O "$MESHRDF_HOME/data/desc$YEAR.dtd"
+    wget "$URI/qual$YEAR.dtd" -O "$MESHRDF_HOME/data/qual$YEAR.dtd"
+    wget "$URI/supp$YEAR.dtd" -O "$MESHRDF_HOME/data/supp$YEAR.dtd"
+fi
 

--- a/bin/mesh-xml2rdf.sh
+++ b/bin/mesh-xml2rdf.sh
@@ -30,6 +30,17 @@ else
 fi
 cd $($READLINK -e `dirname $0`/..)
 
+while getopts "h:j:y:u" opt; do
+  case $opt in
+    h) export MESHRDF_HOME=$OPTARG ;;
+    j) export SAXON_JAR=$OPTARG ;;
+    y) export MESHRDF_YEAR=$OPTARG ;; 
+    u) export MESHRDF_URI_YEAR="yes" ;;
+    *) echo "Usage: $0 [-h mesh-rdf-home] [-j saxon-jar-path] [-y year ]" 1>&2 ; exit 1 ;;
+  esac
+done
+shift $(($OPTIND - 1))
+
 # Check for some needed environment variables
 if [ -z "$MESHRDF_HOME" ]; then
     echo "Please define MESHRDF_HOME environment variable" 1>&2

--- a/xslt/desc.xsl
+++ b/xslt/desc.xsl
@@ -18,6 +18,7 @@
     <xsl:for-each select="DescriptorRecordSet/DescriptorRecord">
 
       <xsl:variable name='descriptor_id' select='DescriptorUI'/>
+      <xsl:variable name='descriptor_label' select='DescriptorName/String'/>
       
       <!--
         Transformation rule: meshv:identifier
@@ -27,7 +28,7 @@
           <xsl:value-of select="$descriptor_id"/>
         </uri>
       </xsl:variable>
-      
+
       <xsl:call-template name='triple'>
         <xsl:with-param name="doc">
           <desc>This relation states that a descriptor record has a unique identifier.</desc>
@@ -82,7 +83,7 @@
           <xsl:copy-of select="$descriptor_uri"/>
           <uri prefix='&rdfs;'>label</uri>
           <literal lang='en'>
-            <xsl:value-of select="DescriptorName/String"/>
+            <xsl:value-of select='$descriptor_label'/>
           </literal>
         </xsl:with-param>
       </xsl:call-template>
@@ -126,6 +127,22 @@
             <xsl:copy-of select='$dqpair_uri'/>
             <uri prefix='&rdf;'>type</uri>
             <uri prefix='&meshv;'>AllowedDescriptorQualifierPair</uri>
+          </xsl:with-param>
+        </xsl:call-template>
+
+        <!--
+          Give it a label
+        -->
+        <xsl:call-template name='triple'>
+          <xsl:with-param name="doc">
+            <desc>Provide a name for the AllowedDescriptorQualifierPair</desc>
+          </xsl:with-param>
+          <xsl:with-param name="spec">
+            <xsl:copy-of select='$dqpair_uri'/>
+            <uri prefix='&rdfs;'>label</uri>
+            <literal lang='en'>
+              <xsl:value-of select="concat($descriptor_label, '/', QualifierReferredTo/QualifierName/String)"/>
+            </literal>
           </xsl:with-param>
         </xsl:call-template>
 
@@ -200,6 +217,22 @@
           </xsl:with-param>
         </xsl:call-template>
         
+        <!-- 
+          Give it a label
+        -->
+        <xsl:call-template name='triple'>
+          <xsl:with-param name="doc">
+            <desc>Provide a label for the DisallowedDescriptorQualifierPair.</desc>
+          </xsl:with-param>
+          <xsl:with-param name="spec">
+            <xsl:copy-of select='$ecin_uri'/>
+            <uri prefix='&rdfs;'>label</uri>
+            <literal lang='en'>
+              <xsl:value-of select="concat(ECIN/DescriptorReferredTo/DescriptorName/String,
+                                           '/', ECIN/QualifierReferredTo/QualifierName/String)"/>
+            </literal>
+          </xsl:with-param>
+        </xsl:call-template>
         <!-- 
           Link it back to the descriptor
         -->


### PR DESCRIPTION
- This change only updates the scripts.
- I stopped downloading the pa$YEAR.xml file
- I changed the code to download DTDs only for years <= 2015
- I added convenient parameters through getopts, but could use long options without getopts if preferred