### PR TITLE
Release URI preserving algorithm and README changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # MeSH® RDF
 
-[![Join the chat at https://gitter.im/HHS/meshrdf](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/HHS/meshrdf?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-
 ***Status:  Beta.  Feedback is [welcome](https://github.com/HHS/meshrdf/issues).***
 
 This repository contains a set of XSLT files that transform MeSH XML into RDF, and also contains
@@ -11,7 +9,7 @@ the content for the technical documentation pages, deployed as a set of GitHub p
 Please see that technical documentation for details about the data model, and how this new
 RDF version of MeSH relates to the XML from which it derives.
 
-The rest of this README describes how to set up a development environment, perform the
+The rest of this README describes how to set up a development environment and perform the
 transformations yourself, if you are interested in doing that.  
 
 All the instructions assume
@@ -42,28 +40,29 @@ $MESHRDF_HOME to point to that location.  For example,
     export MESHRDF_HOME=/var/data/mesh-rdf
 
 You can run the script *bin/fetch-mesh-xml.sh*, which downloads all the XML and corresponding
-DTD files from the NLM FTP server.  It saves them to the *data* subdirectory of $MESHRDF_HOME.
+DTD files from the NLM FTP server. For now, run it with the following command:
+
+    MESHRDF_URI=ftp://ftp.nlm.nih.gov/online/mesh/.xmlmesh bin/fetch-mesh-xml.sh
+
+This saves the XML files to the *data* subdirectory of $MESHRDF_HOME.
 
 By default, it downloads the following:
 
-* desc2014.dtd
-* desc2014.xml
-* pa2014.dtd
-* pa2014.xml
-* qual2014.dtd
-* qual2014.xml
-* supp2014.dtd
-* supp2014.xml
+* desc2015.dtd
+* desc2015.xml
+* pa2015.dtd
+* pa2015.xml
+* qual2015.dtd
+* qual2015.xml
+* supp2015.dtd
+* supp2015.xml
 
 If you want to download a different year's data, set the MESHRDF_YEAR environment variable
 before executing the script. For example,
 
-    MESHRDF_YEAR=2015 bin/fetch-mesh-xml.sh
-
-***Note that at the time of this writing, the 2015 MeSH XML files have not yet been deployed
-to that location.*** To specify the actual location for these files, use this command line:
-
-    MESHRDF_YEAR=2015 MESHRDF_URI=ftp://ftp.nlm.nih.gov/online/mesh/.xmlmesh bin/fetch-mesh-xml.sh
+    MESHRDF_YEAR=2014 \
+    MESHRDF_URI=ftp://ftp.nlm.nih.gov/online/mesh/.xmlmesh \
+    bin/fetch-mesh-xml.sh
 
 
 ### Getting Saxon
@@ -99,7 +98,7 @@ The conversion script is *mesh-xml2rdf.sh*. This shell script will run the XSLTs
 the three main MeSH XML files into RDF N-Triples format, and put the results into the 
 *$MESHRDF_HOME/out* directory. 
 
-By default, it looks for 2014 data files, and will produce *mesh.nt*, which is the 
+By default, it looks for 2015 data files, and will produce *mesh.nt*, which is the 
 RDF in N-triples format, and *mesh.nt.gz*, a gzipped version. Also by default, these 
 data files will have RDF URIs that do not include the year. For example, the descriptor for 
 Ofloxacin would have the URI http://id.nlm.nih.gov/mesh/D015242.
@@ -107,19 +106,19 @@ Ofloxacin would have the URI http://id.nlm.nih.gov/mesh/D015242.
 As with the fetch script, described above, you can use the MESHRDF_YEAR environment variable
 to specify that it convert a different set of data files. For example:
 
-    MESHRDF_YEAR=2015 bin/mesh-xml2rdf.sh
+    MESHRDF_YEAR=2014 bin/mesh-xml2rdf.sh
 
-This uses the 2015 data files to produce the "current" RDF output files *out/mesh.nt*
+This uses the 2014 data files to produce the "current" RDF output files *out/mesh.nt*
 and *out/mesh.nt.gz*.
 
 To produce RDF data that has URIs with the year, then you should also set the
-MESHRDF_URI_YEAR variable to "yes".  Thus, the following uses the 2015 MeSH XML files to
+MESHRDF_URI_YEAR variable to "yes".  Thus, the following uses the 2014 MeSH XML files to
 generate the data that has RDF URIs that include the year:
 
-    MESHRDF_YEAR=2015 MESHRDF_URI_YEAR=yes bin/mesh-xml2rdf.sh
+    MESHRDF_YEAR=2014 MESHRDF_URI_YEAR=yes bin/mesh-xml2rdf.sh
 
-In this case, the output data files will be written to *out/mesh-2015.nt* and
-*out/mesh-2015.nt.gz*.
+In this case, the output data files will be written to *out/mesh-2014.nt* and
+*out/mesh-2014.nt.gz*.
 
 
 ### Generating and converting the sample files

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ generate the data that has RDF URIs that include the year:
 
     MESHRDF_YEAR=2014 MESHRDF_URI_YEAR=yes bin/mesh-xml2rdf.sh
 
-In this case, the output data files will be written to *out/mesh-2014.nt* and
-*out/mesh-2014.nt.gz*.
+In this case, the output data files will be written to *out/2014/mesh2014.nt* and
+*out/2014/mesh2014.nt.gz*.
 
 
 ### Generating and converting the sample files

--- a/bin/mesh-xml2rdf.sh
+++ b/bin/mesh-xml2rdf.sh
@@ -1,8 +1,10 @@
-#!/bin/sh
+#!/bin/bash
 #
 # This script will convert all of the MeSH XML to RDF, assuming that your machine has
 # enough memory and resources.  It will also copy over the vocabulary and void files.
-# It should be run from the root directory of the clone of the hhs/meshrdf repository.
+# This script assumes that it is in the `bin` subdirectory of the clone of the 
+# hhs/meshrdf repository, and it looks for some other files accordingly.
+#
 # The environment variable $MESHRDF_HOME is used to determine the `data` and `out`
 # directories. 
 #
@@ -19,6 +21,16 @@
 #     - the output file will be have the name meshYYYY.nt, and
 #     - it will be put into the output directory $MESHRDF_HOME/out/YYYY
 
+
+# Change directory to the repository root
+if hash greadlink 2>/dev/null; then
+    READLINK=greadlink
+else
+    READLINK=readlink
+fi
+cd $($READLINK -e `dirname $0`/..)
+
+# Check for some needed environment variables
 if [ -z "$MESHRDF_HOME" ]; then
     echo "Please define MESHRDF_HOME environment variable" 1>&2
     exit 1
@@ -46,6 +58,8 @@ else
     URI_PREFIX="http://id.nlm.nih.gov/mesh"
 fi
 
+
+# Do the conversions
 
 mkdir -p $OUTDIR
 
@@ -87,9 +101,11 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+# Copy the meta files
 cp meta/vocabulary.ttl $OUTDIR
 cp meta/void.ttl $OUTDIR
 
+# Set up hard links to version-specific vocabulary and void 
 cd $OUTDIR
 
 vocab_version=`awk '$1~/versionInfo/ { gsub(/"/, "", $2); print $2 }' vocabulary.ttl`

--- a/bin/mesh-xml2rdf.sh
+++ b/bin/mesh-xml2rdf.sh
@@ -2,6 +2,9 @@
 #
 # This script will convert all of the MeSH XML to RDF, assuming that your machine has
 # enough memory and resources.  It will also copy over the vocabulary and void files.
+# It should be run from the root directory of the clone of the hhs/meshrdf repository.
+# The environment variable $MESHRDF_HOME is used to determine the `data` and `out`
+# directories. 
 #
 # It is parameterized according to the following environment variables:
 # - MESHRDF_YEAR - default is "2015". Set this to override the *source* data. In other
@@ -20,7 +23,6 @@ if [ -z "$MESHRDF_HOME" ]; then
     echo "Please define MESHRDF_HOME environment variable" 1>&2
     exit 1
 fi
-cd $MESHRDF_HOME
 
 if [ -z "$SAXON_JAR" ]; then
     echo "Please define SAXON_JAR environment variable" 1>&2
@@ -85,8 +87,8 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-cp $MESHRDF_HOME/meta/vocabulary.ttl $OUTDIR
-cp $MESHRDF_HOME/meta/void.ttl $OUTDIR
+cp meta/vocabulary.ttl $OUTDIR
+cp meta/void.ttl $OUTDIR
 
 cd $OUTDIR
 

--- a/meta/vocabulary.ttl
+++ b/meta/vocabulary.ttl
@@ -458,7 +458,9 @@ dct:description rdf:type :AnnotationProperty .
                                                            
                                                            rdfs:label "nlmClassificationNumber" ;
                                                            
-                                                           dct:description "Each MeSH Descriptor has a corresponding class number in the NLM Classification.  This classification is similar to the Library of Congress Classification (LCC)." .
+                                                           dct:description "Each MeSH Descriptor has a corresponding class number in the NLM Classification.  This classification is similar to the Library of Congress Classification (LCC).";
+
+                                                           rdfs:range xsd:string .
 
 
 

--- a/meta/vocabulary.ttl
+++ b/meta/vocabulary.ttl
@@ -9,7 +9,7 @@
 
 <http://id.nlm.nih.gov/mesh/vocab#> rdf:type :Ontology ;
                                     
-                                    :versionInfo "0.9.3" .
+                                    :versionInfo "0.9.3-dev" .
 
 
 #################################################################

--- a/meta/vocabulary.ttl
+++ b/meta/vocabulary.ttl
@@ -9,7 +9,7 @@
 
 <http://id.nlm.nih.gov/mesh/vocab#> rdf:type :Ontology ;
                                     
-                                    :versionInfo "0.9.1-dev" .
+                                    :versionInfo "0.9" .
 
 
 #################################################################

--- a/meta/vocabulary.ttl
+++ b/meta/vocabulary.ttl
@@ -9,7 +9,7 @@
 
 <http://id.nlm.nih.gov/mesh/vocab#> rdf:type :Ontology ;
                                     
-                                    :versionInfo "0.9" .
+                                    :versionInfo "0.9.1-dev" .
 
 
 #################################################################

--- a/meta/vocabulary.ttl
+++ b/meta/vocabulary.ttl
@@ -9,7 +9,7 @@
 
 <http://id.nlm.nih.gov/mesh/vocab#> rdf:type :Ontology ;
                                     
-                                    :versionInfo "0.9.3-dev" .
+                                    :versionInfo "0.9.3" .
 
 
 #################################################################

--- a/meta/void.ttl
+++ b/meta/void.ttl
@@ -15,7 +15,7 @@
     dcterms:creator "U.S. National Library of Medicine" ;
     dcterms:date "2014-11-01"^^xsd:date ;
     foaf:primaryTopic <http://id.nlm.nih.gov/mesh/void#MeSHRDF> ;
-    owl:versionInfo "0.9.3-dev" .
+    owl:versionInfo "0.9.3" .
 
 
 # Metadata description of the Dataset

--- a/meta/void.ttl
+++ b/meta/void.ttl
@@ -15,7 +15,7 @@
     dcterms:creator "U.S. National Library of Medicine" ;
     dcterms:date "2014-11-01"^^xsd:date ;
     foaf:primaryTopic <http://id.nlm.nih.gov/mesh/void#MeSHRDF> ;
-    owl:versionInfo "0.9.3" .
+    owl:versionInfo "0.9.3-dev" .
 
 
 # Metadata description of the Dataset

--- a/meta/void.ttl
+++ b/meta/void.ttl
@@ -57,15 +57,7 @@
     void:exampleResource <http://id.nlm.nih.gov/mesh/D000001> ;
 
 # FTP dump file
-    void:dataDump "ftp://ftp.nlm.nih.gov/online/mesh/2014/desc2014.nt" ;
-    void:dataDump "ftp://ftp.nlm.nih.gov/online/mesh/2014/qual2014.nt" ;
-    void:dataDump "ftp://ftp.nlm.nih.gov/online/mesh/2014/supp2014.nt" ;
+    void:dataDump "ftp://ftp.nlm.nih.gov/online/mesh/mesh.nt" ;
+    void:dataDump "ftp://ftp.nlm.nih.gov/online/mesh/2016/mesh2016.nt" ;
+    void:dataDump "ftp://ftp.nlm.nih.gov/online/mesh/2015/mesh2015.nt" .
 
-# triple count
-    void:triples "16644674"^^xsd:long ;
-
-# entity count
-    void:entities "1925662"^^xsd:long ;
-
-# distinct subject
-    void:distinctSubjects "1925662"^^xsd:long .

--- a/meta/void.ttl
+++ b/meta/void.ttl
@@ -15,7 +15,7 @@
     dcterms:creator "U.S. National Library of Medicine" ;
     dcterms:date "2014-11-01"^^xsd:date ;
     foaf:primaryTopic <http://id.nlm.nih.gov/mesh/void#MeSHRDF> ;
-    owl:versionInfo "0.9" .
+    owl:versionInfo "0.9.1-dev" .
 
 
 # Metadata description of the Dataset

--- a/meta/void.ttl
+++ b/meta/void.ttl
@@ -15,7 +15,7 @@
     dcterms:creator "U.S. National Library of Medicine" ;
     dcterms:date "2014-11-01"^^xsd:date ;
     foaf:primaryTopic <http://id.nlm.nih.gov/mesh/void#MeSHRDF> ;
-    owl:versionInfo "0.9.1-dev" .
+    owl:versionInfo "0.9" .
 
 
 # Metadata description of the Dataset


### PR DESCRIPTION
- Changes to `README.md` to match current logic
- Changes to `vocabulary.ttl` and `void.ttl` datatype property descriptions
- Add -o path option to `mesh-xml2rdf.sh`