### PR TITLE
Update MeshStatus to only query Virtuoso when not updating

### DIFF
--- a/webui/src/main/java/gov/nih/nlm/lode/servlet/MeshStatus.java
+++ b/webui/src/main/java/gov/nih/nlm/lode/servlet/MeshStatus.java
@@ -95,25 +95,6 @@ public class MeshStatus {
         setHttpdOK(true);
         setTomcatOK(true);
 
-        // Check status of Virtuoso DB server
-        Connection connection = getVirtuosoConnection();
-        if (null != connection) {
-            setVirtuosoOK(true);
-        } else {
-            setVirtuosoOK(false);
-        }
-
-        // Check Virtuoso data
-        if (virtuosoHasData(connection)) {
-            setMeshdataOK(true);
-        } else {
-            setMeshdataOK(false);
-        }
-
-        if (null != connection) {
-            try { connection.close(); } catch (SQLException e) { }
-        }
-
         // Check whether we are currently updating
         if (updatesPath != null) {
             File updatesFile = new File(updatesPath);
@@ -125,6 +106,30 @@ public class MeshStatus {
                 if ((now - updatesFile.lastModified()) > maxMillis) {
                     setUpdateError(true);
                 }
+            }
+        }
+
+        if (isUpdating()) {
+            setVirtuosoOK(false);
+            setMeshdataOK(false);
+        } else {
+            // Check status of Virtuoso DB server
+            Connection connection = getVirtuosoConnection();
+            if (null != connection) {
+                setVirtuosoOK(true);
+            } else {
+                setVirtuosoOK(false);
+            }
+
+            // Check Virtuoso data
+            if (virtuosoHasData(connection)) {
+                setMeshdataOK(true);
+            } else {
+                setMeshdataOK(false);
+            }
+
+            if (null != connection) {
+                try { connection.close(); } catch (SQLException e) { }
             }
         }
     }
@@ -180,7 +185,7 @@ public class MeshStatus {
     protected int getStatusCode() {
         if (isVirtuosoOK() && isMeshdataOK() && !isUpdating() && !isUpdateError()) {
             return STATUS_OK;
-        } else if (isVirtuosoOK() && this.isUpdating() && !isUpdateError()) {
+        } else if (this.isUpdating() && !isUpdateError()) {
             return STATUS_UPDATING;
         } else {
             return STATUS_ERROR;

--- a/webui/src/test/java/gov/nih/nlm/lode/tests/MeshStatusTest.java
+++ b/webui/src/test/java/gov/nih/nlm/lode/tests/MeshStatusTest.java
@@ -65,8 +65,8 @@ public class MeshStatusTest extends AbstractTestNGSpringContextTests {
 
         assertThat(status.isHttpdOK(), is(true));
         assertThat(status.isTomcatOK(), is(true));
-        assertThat(status.isVirtuosoOK(), is(true));
-        assertThat(status.isMeshdataOK(), is(true));
+        assertThat(status.isVirtuosoOK(), is(false));
+        assertThat(status.isMeshdataOK(), is(false));
         assertThat(status.isUpdating(), is(true));
         assertThat(status.isUpdateError(), is(false));
         assertThat(status.getStatus(), is(equalTo("Status: Updating")));
@@ -79,8 +79,8 @@ public class MeshStatusTest extends AbstractTestNGSpringContextTests {
 
         assertThat(status.isHttpdOK(), is(true));
         assertThat(status.isTomcatOK(), is(true));
-        assertThat(status.isVirtuosoOK(), is(true));
-        assertThat(status.isMeshdataOK(), is(true));
+        assertThat(status.isVirtuosoOK(), is(false));
+        assertThat(status.isMeshdataOK(), is(false));
         assertThat(status.isUpdating(), is(true));
         assertThat(status.isUpdateError(), is(true));
         assertThat(status.getStatus(), is(equalTo("Status: Error")));


### PR DESCRIPTION
- This should mean that the Virtuoso process is not queried even if
  /status is hit during an update.
- This should allow the update with --keepuris to complete.