### PR TITLE
Prepare for Bamboo CI/CD

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>gov.nih.nlm.lode</groupId>
+    <artifactId>meshrdf</artifactId>
+    <packaging>pom</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>NLM MeSH RDF parent project</name>
+
+    <modules>
+        <module>webui</module>
+    </modules>
+
+</project>

--- a/webui/.gitignore
+++ b/webui/.gitignore
@@ -3,3 +3,5 @@
 /test-output
 /.settings/
 /.springBeans
+/.project
+/.classpath

--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -13,7 +13,7 @@
         <skipTests>false</skipTests>
 
         <!-- Lodestar version -->
-        <lodestar.version>1.4.1-SNAPSHOT</lodestar.version>
+        <lodestar.version>1.4-SNAPSHOT</lodestar.version>
 
         <!-- Requires that virtuoso lodestar be similarly built -->
         <org.springframework.version>4.3.3.RELEASE</org.springframework.version>
@@ -118,6 +118,13 @@
     </build>
 
     <dependencies>
+
+        <!-- Will pull in the other requirements -->
+        <dependency>
+            <groupId>ebi-lode</groupId>
+            <artifactId>lode-virtuoso-impl</artifactId>
+            <version>${lodestar.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>ebi-lode</groupId>

--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -4,8 +4,13 @@
     <groupId>gov.nih.nlm.lode</groupId>
     <artifactId>mesh</artifactId>
     <packaging>war</packaging>
-    <version>1.0-SNAPSHOT</version>
     <name>NLM Overlay for EBI Lodestar web-ui</name>
+
+    <parent>
+        <groupId>gov.nih.nlm.lode</groupId>
+        <artifactId>meshrdf</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -26,11 +31,6 @@
         <!-- Production parameters -->
         <updatesPath>/usr/nlm/meshlocal/state/updating</updatesPath>
         <updateMaxSeconds>10800</updateMaxSeconds>
-
-
-        <!-- No defaults for these - they must come from profiles -->
-        <!-- <release.repo.url> -->
-        <!-- <snapshot.repo.url> -->
     </properties>
 
     <build>

--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -4,13 +4,16 @@
     <groupId>gov.nih.nlm.lode</groupId>
     <artifactId>mesh</artifactId>
     <packaging>war</packaging>
-    <version>1.0</version>
+    <version>1.0-SNAPSHOT</version>
     <name>NLM Overlay for EBI Lodestar web-ui</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <groups>unit</groups>
         <skipTests>false</skipTests>
+
+        <!-- Lodestar version -->
+        <lodestar.version>1.4.1-SNAPSHOT</lodestar.version>
 
         <!-- Requires that virtuoso lodestar be similarly built -->
         <org.springframework.version>4.3.3.RELEASE</org.springframework.version>
@@ -23,6 +26,11 @@
         <!-- Production parameters -->
         <updatesPath>/usr/nlm/meshlocal/state/updating</updatesPath>
         <updateMaxSeconds>10800</updateMaxSeconds>
+
+
+        <!-- No defaults for these - they must come from profiles -->
+        <!-- <release.repo.url> -->
+        <!-- <snapshot.repo.url> -->
     </properties>
 
     <build>
@@ -111,17 +119,10 @@
 
     <dependencies>
 
-        <!-- NOTE: Both lode-core-servlet and lode-core-api will be enabled transitively -->
-        <dependency>
-            <groupId>ebi-lode</groupId>
-            <artifactId>lode-virtuoso-impl</artifactId>
-            <version>1.4-SNAPSHOT</version>
-        </dependency>
-
         <dependency>
             <groupId>ebi-lode</groupId>
             <artifactId>web-ui</artifactId>
-            <version>1.4-SNAPSHOT</version>
+            <version>${lodestar.version}</version>
             <type>war</type>
             <scope>runtime</scope>
         </dependency>
@@ -223,5 +224,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <distributionManagement>
+        <repository>
+            <id>release-local</id>
+            <name>Repository for MeSH RDF releases</name>
+            <url>${release.repo.url}</url>
+        </repository>
+        <snapshotRepository>
+            <id>snapshot-local</id>
+            <name>Repository for MeSH RDF snapshots</name>
+            <url>${snapshot.repo.url}</url>
+        </snapshotRepository>
+    </distributionManagement>
 
 </project>


### PR DESCRIPTION
- Update MeSH RDF webui sub-directory to work with deploy plugin
- Get version from a parent POM, by referring to parent pom specifically, but it is still not clear how this helps us.