### PR TITLE
Updates to support 2018 MeSH XML conversion and make default

### DIFF
--- a/bin/fetch-mesh-xml.sh
+++ b/bin/fetch-mesh-xml.sh
@@ -19,7 +19,7 @@ fi
 mkdir -p "$MESHRDF_HOME/data"
 
 # CAn override default year with MESHRDF_YEAR environment variable
-YEAR=${MESHRDF_YEAR:-2017}
+YEAR=${MESHRDF_YEAR:-2018}
 
 # Can override default URI with MESHRDF_URI environment variable
 URI=${MESHRDF_URI:-ftp://ftp.nlm.nih.gov/online/mesh/$YEAR}

--- a/bin/mesh-xml2rdf.sh
+++ b/bin/mesh-xml2rdf.sh
@@ -57,7 +57,7 @@ if [ -z "$SAXON_JAR" ]; then
 fi
 
 # Can override default year with MESHRDF_YEAR environment variable
-YEAR=${MESHRDF_YEAR:-2017}
+YEAR=${MESHRDF_YEAR:-2018}
 
 # Set the output file name, and the parameter that controls the RDF URIs,
 # according to whether or not MESHRDF_URI_YEAR is "yes"

--- a/meta/vocabulary.ttl
+++ b/meta/vocabulary.ttl
@@ -741,7 +741,8 @@ rdfs:label rdf:type :DatatypeProperty .
                                                 rdfs:subClassOf <http://id.nlm.nih.gov/mesh/vocab#SupplementaryConceptRecord> ;
 
                                                 :disjointWith <http://id.nlm.nih.gov/mesh/vocab#SCR_Disease> ,
-                                                              <http://id.nlm.nih.gov/mesh/vocab#SCR_Protocol> ;
+                                                              <http://id.nlm.nih.gov/mesh/vocab#SCR_Protocol> ,
+                                                              <http://id.nlm.nih.gov/mesh/vocab#SCR_Organism>;
 
                                                 dct:description "These are chemicals, drugs, enzymes, vitamins, etc." .
 
@@ -755,7 +756,8 @@ rdfs:label rdf:type :DatatypeProperty .
 
                                                rdfs:subClassOf <http://id.nlm.nih.gov/mesh/vocab#SupplementaryConceptRecord> ;
 
-                                               :disjointWith <http://id.nlm.nih.gov/mesh/vocab#SCR_Protocol> ;
+                                               :disjointWith <http://id.nlm.nih.gov/mesh/vocab#SCR_Protocol> ,
+                                                             <http://id.nlm.nih.gov/mesh/vocab#SCR_Organism>;
 
                                                dct:description "SCR Diseases were originally brought into MeSH from a list maintained by the Office of Rare Diseases Research." .
 
@@ -769,7 +771,20 @@ rdfs:label rdf:type :DatatypeProperty .
 
                                                 rdfs:subClassOf <http://id.nlm.nih.gov/mesh/vocab#SupplementaryConceptRecord> ;
 
+                                                :disjointWith <http://id.nlm.nih.gov/mesh/vocab#SCR_Organism>;
+
                                                 dct:description "MeSH protocols are therapies in the domain of cancer treatment." .
+
+
+###  http://id.nlm.nih.gov/mesh/vocab#SCR_Organism
+
+<http://id.nlm.nih.gov/mesh/vocab#SCR_Organism> rdf:type :Class ;
+
+                                                rdfs:label "MeSH SCR Organism" ;
+
+                                                rdfs:subClassOf <http://id.nlm.nih.gov/mesh/vocab#SupplementaryConceptRecord> ;
+
+                                                dct:description "SCR Organisms includes viruses and more broadly organisms (B cat)." .
 
 
 

--- a/meta/void.ttl
+++ b/meta/void.ttl
@@ -58,6 +58,7 @@
 
 # FTP dump file
     void:dataDump "ftp://ftp.nlm.nih.gov/online/mesh/rdf/mesh.nt" ;
+    void:dataDump "ftp://ftp.nlm.nih.gov/online/mesh/rdf/2018/mesh2018.nt" ;
     void:dataDump "ftp://ftp.nlm.nih.gov/online/mesh/rdf/2017/mesh2017.nt" ;
     void:dataDump "ftp://ftp.nlm.nih.gov/online/mesh/rdf/2016/mesh2016.nt" ;
     void:dataDump "ftp://ftp.nlm.nih.gov/online/mesh/rdf/2015/mesh2015.nt" .

--- a/webui/src/main/webapp/vocabulary.ttl
+++ b/webui/src/main/webapp/vocabulary.ttl
@@ -741,7 +741,8 @@ rdfs:label rdf:type :DatatypeProperty .
                                                 rdfs:subClassOf <http://id.nlm.nih.gov/mesh/vocab#SupplementaryConceptRecord> ;
 
                                                 :disjointWith <http://id.nlm.nih.gov/mesh/vocab#SCR_Disease> ,
-                                                              <http://id.nlm.nih.gov/mesh/vocab#SCR_Protocol> ;
+                                                              <http://id.nlm.nih.gov/mesh/vocab#SCR_Protocol> ,
+                                                              <http://id.nlm.nih.gov/mesh/vocab#SCR_Organism>;
 
                                                 dct:description "These are chemicals, drugs, enzymes, vitamins, etc." .
 
@@ -755,7 +756,8 @@ rdfs:label rdf:type :DatatypeProperty .
 
                                                rdfs:subClassOf <http://id.nlm.nih.gov/mesh/vocab#SupplementaryConceptRecord> ;
 
-                                               :disjointWith <http://id.nlm.nih.gov/mesh/vocab#SCR_Protocol> ;
+                                               :disjointWith <http://id.nlm.nih.gov/mesh/vocab#SCR_Protocol> ,
+                                                             <http://id.nlm.nih.gov/mesh/vocab#SCR_Organism>;
 
                                                dct:description "SCR Diseases were originally brought into MeSH from a list maintained by the Office of Rare Diseases Research." .
 
@@ -769,7 +771,20 @@ rdfs:label rdf:type :DatatypeProperty .
 
                                                 rdfs:subClassOf <http://id.nlm.nih.gov/mesh/vocab#SupplementaryConceptRecord> ;
 
+                                                :disjointWith <http://id.nlm.nih.gov/mesh/vocab#SCR_Organism>;
+
                                                 dct:description "MeSH protocols are therapies in the domain of cancer treatment." .
+
+
+###  http://id.nlm.nih.gov/mesh/vocab#SCR_Organism
+
+<http://id.nlm.nih.gov/mesh/vocab#SCR_Organism> rdf:type :Class ;
+
+                                                rdfs:label "MeSH SCR Organism" ;
+
+                                                rdfs:subClassOf <http://id.nlm.nih.gov/mesh/vocab#SupplementaryConceptRecord> ;
+
+                                                dct:description "SCR Organisms includes viruses and more broadly organisms (B cat)." .
 
 
 

--- a/webui/src/main/webapp/void.ttl
+++ b/webui/src/main/webapp/void.ttl
@@ -58,6 +58,7 @@
 
 # FTP dump file
     void:dataDump "ftp://ftp.nlm.nih.gov/online/mesh/rdf/mesh.nt" ;
+    void:dataDump "ftp://ftp.nlm.nih.gov/online/mesh/rdf/2018/mesh2018.nt" ;
     void:dataDump "ftp://ftp.nlm.nih.gov/online/mesh/rdf/2017/mesh2017.nt" ;
     void:dataDump "ftp://ftp.nlm.nih.gov/online/mesh/rdf/2016/mesh2016.nt" ;
     void:dataDump "ftp://ftp.nlm.nih.gov/online/mesh/rdf/2015/mesh2015.nt" .

--- a/xslt/common.xsl
+++ b/xslt/common.xsl
@@ -74,6 +74,7 @@
     <xsl:param name='spec'/>
     <xsl:if test='count($spec/*) != 3'>
       <xsl:message terminate="yes">
+        <!-- <xsl:value-of select="concat('at line ', saxon:line-number())"/> -->
         <xsl:text>Wrong number of element children of spec param of triple template</xsl:text>
       </xsl:message>
     </xsl:if>

--- a/xslt/supp.xsl
+++ b/xslt/supp.xsl
@@ -59,6 +59,9 @@
             <xsl:when test='@SCRClass = "3"'>
               <uri prefix='&meshv;'>SCR_Disease</uri>
             </xsl:when>
+            <xsl:when test='@SCRClass = "4"'>
+              <uri prefix='&meshv;'>SCR_Organism</uri>
+            </xsl:when>
           </xsl:choose>
         </xsl:with-param>
       </xsl:call-template>


### PR DESCRIPTION
https://www.nlm.nih.gov/mesh/ mentions at this point "A new class of Supplementary Concept Records (SCRs) has been released".   Most of these changes are in support of this, and some changes are just to change defaults to year 2018 and include 2018 data dump link.