### PR TITLE
Release 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>gov.nih.nlm.lode</groupId>
     <artifactId>meshrdf</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.9</version>
+    <version>1.1.0-SNAPSHOT</version>
     <name>NLM MeSH RDF parent project</name>
     <scm>
         <url>https://github.com/HHS/meshrdf</url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>gov.nih.nlm.lode</groupId>
     <artifactId>meshrdf</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <name>NLM MeSH RDF parent project</name>
     <scm>
         <url>https://github.com/HHS/meshrdf</url>

--- a/webui/package.json
+++ b/webui/package.json
@@ -20,7 +20,7 @@
     "codemirror": "5.46.0",
     "font-awesome": "4.7.0",
     "handlebars": "4.1.2",
-    "jquery": "3.4.0",
+    "jquery": "3.4.1",
     "jquery-ui-dist": "1.12.1"
   },
   "devDependencies": {

--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>gov.nih.nlm.lode</groupId>
         <artifactId>meshrdf</artifactId>
-        <version>1.0.9</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>gov.nih.nlm.lode</groupId>
         <artifactId>meshrdf</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.1.0</version>
     </parent>
 
     <properties>

--- a/webui/src/main/webapp/internal/swaggerui.jsp
+++ b/webui/src/main/webapp/internal/swaggerui.jsp
@@ -3,7 +3,9 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MeSH RDF Swagger API</title>
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.22.0/swagger-ui.css" >
     <!-- 
@@ -36,8 +38,8 @@
   <body>
     <div id="swagger-ui"></div>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.22.0/swagger-ui-bundle.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.22.0/swagger-ui-standalone-preset.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.23.1/swagger-ui-bundle.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/3.23.1/swagger-ui-standalone-preset.js"></script>
     <script id="swagger-start">
     window.onload = function() {
       // Begin Swagger UI call region

--- a/webui/src/test/java/gov/nih/nlm/lode/tests/ExplorerTest.java
+++ b/webui/src/test/java/gov/nih/nlm/lode/tests/ExplorerTest.java
@@ -1,7 +1,7 @@
 package gov.nih.nlm.lode.tests;
 
-import org.openqa.selenium.WebElement;
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
 import org.testng.annotations.Test;
 
 public class ExplorerTest extends LodeBaseTest {
@@ -60,7 +60,7 @@ public class ExplorerTest extends LodeBaseTest {
     public void testSCRChemical() {
         openExplorerPage("C000621506");
         shouldBeExplorerPage();
-        shouldBeAbout("CXXC5 protein, zebrafish");
+        shouldBeAbout("cxxc5a protein, zebrafish");
         shouldBeResourceType("MeSH SCR Chemical");
     }
 


### PR DESCRIPTION
The main change in this release is to fix the /swagger/ui page when used in Internet Explorer 11.  On-premise, we generally have this set in Compatibility Mode by default, and then the web server must explicitly send X-UA-Compatible to relax that.

Another change is a patch to jquery for security.