### PR TITLE
MeSH RDF 1.1.6 - update from 2019 to 2020 plus features

### DIFF
--- a/bin/fetch-mesh-xml.sh
+++ b/bin/fetch-mesh-xml.sh
@@ -19,10 +19,10 @@ fi
 mkdir -p "$MESHRDF_HOME/data"
 
 # CAn override default year with MESHRDF_YEAR environment variable
-YEAR=${MESHRDF_YEAR:-2019}
+YEAR=${MESHRDF_YEAR:-2020}
 
 # Can override default URI with MESHRDF_URI environment variable
-if [ $YEAR -le "2017" ]; then
+if [ $YEAR -lt "2020" ]; then
     URI=${MESHRDF_URI:-ftp://ftp.nlm.nih.gov/online/mesh/$YEAR}
 else
     URI=${MESHRDF_URI:-ftp://ftp.nlm.nih.gov/online/mesh/MESH_FILES/xmlmesh}

--- a/bin/mesh-xml2rdf.sh
+++ b/bin/mesh-xml2rdf.sh
@@ -63,7 +63,7 @@ fi
 _CP="$SAXON_JAR"
 
 # Can override default year with MESHRDF_YEAR environment variable
-YEAR=${MESHRDF_YEAR:-2019}
+YEAR=${MESHRDF_YEAR:-2020}
 
 # Set the output file name, and the parameter that controls the RDF URIs,
 # according to whether or not MESHRDF_URI_YEAR is "yes"
@@ -126,7 +126,7 @@ if [ -f "$MESHRDF_HOME/data/cns-disease-2014AB.nt" ]; then
         "$MESHRDF_HOME/data/cns-disease-2014AB.nt" >> "$OUTFILE-dups.nt"
 fi
 
-sort -u -T"$OUTDIR" "$OUTFILE-dups.nt" > "$OUTFILE.nt"
+/usr/bin/sort -u -T"$OUTDIR" "$OUTFILE-dups.nt" > "$OUTFILE.nt"
 if [ $? -ne 0 ]; then 
     echo "Error deduplicating $OUTFILE-dups.nt" 1>&2
     exit 1

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>gov.nih.nlm.lode</groupId>
     <artifactId>meshrdf</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.1.6</version>
     <name>NLM MeSH RDF parent project</name>
     <scm>
         <url>https://github.com/HHS/meshrdf</url>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <snapshot.repo.url>http://localhost:8081/nexus/libs-snapshot-local</snapshot.repo.url>
 
         <!-- Versions -->
-        <springframework.version>4.3.22.RELEASE</springframework.version>
+        <springframework.version>4.3.25.RELEASE</springframework.version>
         <lodestar.version>1.4.2-SNAPSHOT</lodestar.version>
         <logback.version>1.2.3</logback.version>
         <slf4j.version>1.7.28</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>gov.nih.nlm.lode</groupId>
     <artifactId>meshrdf</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.5-SNAPSHOT</version>
+    <version>1.1.5</version>
     <name>NLM MeSH RDF parent project</name>
     <scm>
         <url>https://github.com/HHS/meshrdf</url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>gov.nih.nlm.lode</groupId>
     <artifactId>meshrdf</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.5</version>
+    <version>1.1.6-SNAPSHOT</version>
     <name>NLM MeSH RDF parent project</name>
     <scm>
         <url>https://github.com/HHS/meshrdf</url>

--- a/webui/package.json
+++ b/webui/package.json
@@ -20,7 +20,7 @@
     "codemirror": "5.46.0",
     "es6-object-assign": "1.1.0",
     "font-awesome": "4.7.0",
-    "handlebars": "4.1.2",
+    "handlebars": "4.4.2",
     "jquery": "3.4.1",
     "jquery-ui-dist": "1.12.1",
     "url-polyfill": "1.1.7"

--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>gov.nih.nlm.lode</groupId>
         <artifactId>meshrdf</artifactId>
-        <version>1.1.6-SNAPSHOT</version>
+        <version>1.1.6</version>
     </parent>
 
     <properties>

--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -358,6 +358,11 @@
             <artifactId>lucene-analyzers-common</artifactId>
             <version>7.4.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.ibm.icu</groupId>
+            <artifactId>icu4j</artifactId>
+            <version>64.2</version>
+        </dependency>
 
         <dependency>
             <groupId>org.tuckey</groupId>

--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -331,7 +331,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.9.2</version>
+            <version>2.10.0</version>
             <scope>compile</scope>
         </dependency>
         
@@ -339,7 +339,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.9</version>
+            <version>2.10.0</version>
             <scope>compile</scope>
         </dependency>
 

--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>gov.nih.nlm.lode</groupId>
         <artifactId>meshrdf</artifactId>
-        <version>1.1.5</version>
+        <version>1.1.6-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -21,6 +21,9 @@
         <updatesPath>/usr/nlm/meshlocal/state/updating</updatesPath>
         <updateMaxSeconds>10800</updateMaxSeconds>
         <logPrefix></logPrefix>
+        <qualtrics.url></qualtrics.url>
+        <qualtrics.width></qualtrics.width>
+        <qualtrics.height></qualtrics.height>
     </properties>
 
     <build>

--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>gov.nih.nlm.lode</groupId>
         <artifactId>meshrdf</artifactId>
-        <version>1.1.5-SNAPSHOT</version>
+        <version>1.1.5</version>
     </parent>
 
     <properties>

--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -23,9 +23,7 @@
         <updateMaxSeconds>10800</updateMaxSeconds>
         <logPrefix></logPrefix>
         <gtmcode>GTM-MT6MLL</gtmcode>
-        <qualtrics.url>https://nlmenterprise.co1.qualtrics.com/jfe/form/SV_cvCBOTdP6FibROJ</qualtrics.url>
-        <qualtrics.width></qualtrics.width>
-        <qualtrics.height></qualtrics.height>
+        <surveyUrl>https://nlmenterprise.co1.qualtrics.com/jfe/form/SV_cvCBOTdP6FibROJ</surveyUrl>
     </properties>
 
     <build>

--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -22,8 +22,9 @@
         <updatesPath>/usr/nlm/meshlocal/state/updating</updatesPath>
         <updateMaxSeconds>10800</updateMaxSeconds>
         <logPrefix></logPrefix>
-        <gtmcode>GTM-MT6MLL</gtmcode>
-        <surveyUrl>https://nlmenterprise.co1.qualtrics.com/jfe/form/SV_cvCBOTdP6FibROJ</surveyUrl>
+        <gtmcode>GTM-PCV9JFW</gtmcode>
+        <meshrdf.year>2020</meshrdf.year>
+        <surveyUrl></surveyUrl>
     </properties>
 
     <build>
@@ -331,7 +332,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.0</version>
+            <version>2.10.1</version>
             <scope>compile</scope>
         </dependency>
         
@@ -339,7 +340,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.10.0</version>
+            <version>2.10.1</version>
             <scope>compile</scope>
         </dependency>
 

--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -18,10 +18,12 @@
     <properties>
         <groups>unit</groups>
         <skipTests>false</skipTests>
+        <!-- These affect context.xml and code be overridden by the container, or by ~/.m2/settings.xml -->
         <updatesPath>/usr/nlm/meshlocal/state/updating</updatesPath>
         <updateMaxSeconds>10800</updateMaxSeconds>
         <logPrefix></logPrefix>
-        <qualtrics.url></qualtrics.url>
+        <gtmcode>GTM-MT6MLL</gtmcode>
+        <qualtrics.url>https://nlmenterprise.co1.qualtrics.com/jfe/form/SV_cvCBOTdP6FibROJ</qualtrics.url>
         <qualtrics.width></qualtrics.width>
         <qualtrics.height></qualtrics.height>
     </properties>

--- a/webui/pom.xml
+++ b/webui/pom.xml
@@ -378,7 +378,7 @@
         <dependency>
             <groupId>gov.nih.nlm.occs</groupId>
             <artifactId>nlm-test-framework</artifactId>
-            <version>2.1.6</version>
+            <version>2.1.7</version>
             <scope>test</scope>
         </dependency>
         

--- a/webui/src/main/filtered/META-INF/context.xml
+++ b/webui/src/main/filtered/META-INF/context.xml
@@ -3,6 +3,11 @@
     <!-- These are pulled into the Spring properties and used as Spring @Value annotations -->
     <Parameter name="updatesPath" value="${updatesPath}" override="true"/>
     <Parameter name="updateMaxSeconds" value="${updateMaxSeconds}" override="true"/>
+    
+    <!-- These are read directly by the lodestar tag library -->
+    <Parameter name="qualtrics.url" value="${qualtrics.url}" override="true"/>
+    <Parameter name="qualtrics.width" value="${qualtrics.width}" override="true"/>
+    <Parameter name="qualtrics.height" value="${qualtrics.height}" override="true"/>
 
     <!-- This is pulled into the logback configuration as a JNDI export -->
     <Environment name="lodestar.log.prefix" value="${logPrefix}" type="java.lang.String" override="true"/>

--- a/webui/src/main/filtered/META-INF/context.xml
+++ b/webui/src/main/filtered/META-INF/context.xml
@@ -7,6 +7,7 @@
     <!-- These are read directly by the lodestar tag library -->
     <Parameter name="gtmcode" value="${gtmcode}" override="true"/>
     <Parameter name="surveyUrl" value="${surveyUrl}" override="true"/>
+    <Parameter name="meshrdf.year" value="${meshrdf.year}" override="true"/>
 
     <!-- This is pulled into the logback configuration as a JNDI export -->
     <Environment name="lodestar.log.prefix" value="${logPrefix}" type="java.lang.String" override="true"/>

--- a/webui/src/main/filtered/META-INF/context.xml
+++ b/webui/src/main/filtered/META-INF/context.xml
@@ -5,6 +5,7 @@
     <Parameter name="updateMaxSeconds" value="${updateMaxSeconds}" override="true"/>
     
     <!-- These are read directly by the lodestar tag library -->
+    <Parameter name="gtmcode" value="${gtmcode}" override="true"/>
     <Parameter name="qualtrics.url" value="${qualtrics.url}" override="true"/>
     <Parameter name="qualtrics.width" value="${qualtrics.width}" override="true"/>
     <Parameter name="qualtrics.height" value="${qualtrics.height}" override="true"/>

--- a/webui/src/main/filtered/META-INF/context.xml
+++ b/webui/src/main/filtered/META-INF/context.xml
@@ -6,7 +6,7 @@
     
     <!-- These are read directly by the lodestar tag library -->
     <Parameter name="gtmcode" value="${gtmcode}" override="true"/>
-    <Parameter name="qualtricsUrl" value="${qualtricsUrl}" override="true"/>
+    <Parameter name="surveyUrl" value="${surveyUrl}" override="true"/>
 
     <!-- This is pulled into the logback configuration as a JNDI export -->
     <Environment name="lodestar.log.prefix" value="${logPrefix}" type="java.lang.String" override="true"/>

--- a/webui/src/main/filtered/META-INF/context.xml
+++ b/webui/src/main/filtered/META-INF/context.xml
@@ -6,9 +6,7 @@
     
     <!-- These are read directly by the lodestar tag library -->
     <Parameter name="gtmcode" value="${gtmcode}" override="true"/>
-    <Parameter name="qualtrics.url" value="${qualtrics.url}" override="true"/>
-    <Parameter name="qualtrics.width" value="${qualtrics.width}" override="true"/>
-    <Parameter name="qualtrics.height" value="${qualtrics.height}" override="true"/>
+    <Parameter name="qualtricsUrl" value="${qualtricsUrl}" override="true"/>
 
     <!-- This is pulled into the logback configuration as a JNDI export -->
     <Environment name="lodestar.log.prefix" value="${logPrefix}" type="java.lang.String" override="true"/>

--- a/webui/src/main/java/gov/nih/nlm/lode/servlet/GTMNoScriptTag.java
+++ b/webui/src/main/java/gov/nih/nlm/lode/servlet/GTMNoScriptTag.java
@@ -21,12 +21,13 @@ public class GTMNoScriptTag extends GTMScriptTag {
             "height=\"0\" width=\"0\" style=\"display:none;visibility:hidden\">"+
             "</iframe></noscript>\n";
 
+    private String gtmcode;
+
     @Override
     public int doStartTag() throws JspException {
         JspWriter out = pageContext.getOut();
         try {
             out.print("<!-- Google Tag Manager (noscript) -->\n");
-            String gtmcode = getGTMCode();
             if (null != gtmcode) {
                 out.print(String.format(TAG_FORMAT, gtmcode));
             }

--- a/webui/src/main/java/gov/nih/nlm/lode/servlet/GTMNoScriptTag.java
+++ b/webui/src/main/java/gov/nih/nlm/lode/servlet/GTMNoScriptTag.java
@@ -21,8 +21,6 @@ public class GTMNoScriptTag extends GTMScriptTag {
             "height=\"0\" width=\"0\" style=\"display:none;visibility:hidden\">"+
             "</iframe></noscript>\n";
 
-    private String gtmcode;
-
     @Override
     public int doStartTag() throws JspException {
         JspWriter out = pageContext.getOut();
@@ -35,7 +33,7 @@ public class GTMNoScriptTag extends GTMScriptTag {
         } catch (IOException e) {
             throw new JspException("IOException", e);
         }
-        return super.doStartTag();
+        return SKIP_BODY;
     }
 
 }

--- a/webui/src/main/java/gov/nih/nlm/lode/servlet/GTMScriptTag.java
+++ b/webui/src/main/java/gov/nih/nlm/lode/servlet/GTMScriptTag.java
@@ -2,8 +2,9 @@ package gov.nih.nlm.lode.servlet;
 
 import java.io.IOException;
 
-import javax.servlet.jsp.JspWriter;
 import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+import javax.servlet.jsp.PageContext;
 import javax.servlet.jsp.tagext.TagSupport;
 
 /**
@@ -12,6 +13,8 @@ import javax.servlet.jsp.tagext.TagSupport;
 public class GTMScriptTag extends TagSupport {
 
     private static final long serialVersionUID = 1L;
+
+    public static final String GTM_PARAM_NAME = "gtmcode";
 
     private static final String TAG_FORMAT =
             "<script>" +
@@ -24,22 +27,20 @@ public class GTMScriptTag extends TagSupport {
             "(window,document,'script','dataLayer','%s');" +
             "</script>\n";
 
-    /**
-     * This is a careful wrapping of the system property, in case some administrator
-     * is using a system property to inject JavaScript or something.
-     *
-     * @return gtmcode - validated gtmcode property
-     */
-    public static String getGTMCode() {
-        return SafeProperty.getProperty("meshrdf.gtmcode", "GTM-[A-Z0-9]+");
+    private String gtmcode;
+
+    @Override
+    public void setPageContext(PageContext context) {
+        super.setPageContext(context);
+        gtmcode = ServletUtils.getParameter(context.getServletContext(), GTM_PARAM_NAME);
     }
 
     @Override
     public int doStartTag() throws JspException {
+
         JspWriter out = pageContext.getOut();
         try {
             out.print("<!-- Google Tag Manager -->\n");
-            String gtmcode = getGTMCode();
             if (null != gtmcode) {
                 out.print(String.format(TAG_FORMAT, gtmcode));
             }

--- a/webui/src/main/java/gov/nih/nlm/lode/servlet/GTMScriptTag.java
+++ b/webui/src/main/java/gov/nih/nlm/lode/servlet/GTMScriptTag.java
@@ -27,7 +27,7 @@ public class GTMScriptTag extends TagSupport {
             "(window,document,'script','dataLayer','%s');" +
             "</script>\n";
 
-    private String gtmcode;
+    protected String gtmcode;
 
     @Override
     public void setPageContext(PageContext context) {
@@ -48,6 +48,6 @@ public class GTMScriptTag extends TagSupport {
         } catch (IOException e) {
             throw new JspException("IOException", e);
         }
-        return super.doStartTag();
+        return SKIP_BODY;
     }
 }

--- a/webui/src/main/java/gov/nih/nlm/lode/servlet/NlmConfigTag.java
+++ b/webui/src/main/java/gov/nih/nlm/lode/servlet/NlmConfigTag.java
@@ -28,8 +28,14 @@ public class NlmConfigTag extends TagSupport {
             + "</script>\n";
 
     public int getMeshYear() {
-        // check whether there is a system property
+        // check whether there is a system property (takes priority)
         Object value = SafeProperty.getProperty(MESHRDF_YEAR, "[0-9]{4}");
+        if (value != null) {
+            return Integer.parseInt((String) value);
+        }
+
+        // check whether there is a container parameter
+        value = ServletUtils.getParameter(pageContext.getServletContext(), MESHRDF_YEAR);
         if (value != null) {
             return Integer.parseInt((String) value);
         }

--- a/webui/src/main/java/gov/nih/nlm/lode/servlet/QualtricsSurveyTag.java
+++ b/webui/src/main/java/gov/nih/nlm/lode/servlet/QualtricsSurveyTag.java
@@ -1,0 +1,47 @@
+package gov.nih.nlm.lode.servlet;
+
+import java.io.IOException;
+
+import javax.servlet.ServletContext;
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.JspWriter;
+import javax.servlet.jsp.PageContext;
+import javax.servlet.jsp.tagext.TagSupport;
+
+
+public class QualtricsSurveyTag extends TagSupport {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String TAG_FORMAT = "<iframe src=\"%s\" height=\"%dpx\" width=\"%dpx\"></iframe>\n";
+
+    public static final String URL_PARAM_NAME = "qualtrics.url";
+    public static final String HEIGHT_PARAM_NAME = "qualtrics.height";
+    public static final String WIDTH_PARAM_NAME = "qualtrics.width";
+
+    private String url;
+    private int height;
+    private int width;
+
+    @Override
+    public void setPageContext(PageContext context) {
+        super.setPageContext(context);
+        ServletContext servletContext = context.getServletContext();
+        url = ServletUtils.getParameter(servletContext, URL_PARAM_NAME);
+        height = ServletUtils.getIntParameter(servletContext, HEIGHT_PARAM_NAME, 600);
+        width = ServletUtils.getIntParameter(servletContext, WIDTH_PARAM_NAME, 800);
+    }
+
+    @Override
+    public int doStartTag() throws JspException {
+        if (url != null) {
+            JspWriter out = pageContext.getOut();
+            try {
+                out.print(String.format(TAG_FORMAT, url, height, width));
+            } catch (IOException e) {
+                throw new JspException("IOException", e);
+            }
+        }
+        return super.doStartTag();
+    }
+}

--- a/webui/src/main/java/gov/nih/nlm/lode/servlet/QualtricsSurveyTag.java
+++ b/webui/src/main/java/gov/nih/nlm/lode/servlet/QualtricsSurveyTag.java
@@ -34,13 +34,15 @@ public class QualtricsSurveyTag extends TagSupport {
 
     @Override
     public int doStartTag() throws JspException {
-        if (url != null) {
-            JspWriter out = pageContext.getOut();
-            try {
+        JspWriter out = pageContext.getOut();
+        try {
+            if (url != null) {
                 out.print(String.format(TAG_FORMAT, url, height, width));
-            } catch (IOException e) {
-                throw new JspException("IOException", e);
+            } else {
+                out.print("<!-- Qualtrics survey not configured -->");
             }
+        } catch (IOException e) {
+            throw new JspException("IOException", e);
         }
         return SKIP_BODY;
     }

--- a/webui/src/main/java/gov/nih/nlm/lode/servlet/QualtricsSurveyTag.java
+++ b/webui/src/main/java/gov/nih/nlm/lode/servlet/QualtricsSurveyTag.java
@@ -42,6 +42,6 @@ public class QualtricsSurveyTag extends TagSupport {
                 throw new JspException("IOException", e);
             }
         }
-        return super.doStartTag();
+        return SKIP_BODY;
     }
 }

--- a/webui/src/main/java/gov/nih/nlm/lode/servlet/ServletUtils.java
+++ b/webui/src/main/java/gov/nih/nlm/lode/servlet/ServletUtils.java
@@ -6,6 +6,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 
 
@@ -47,6 +48,31 @@ public class ServletUtils {
             headers.put(headerName, valuesList);
         }
         return headers;
+    }
+
+    public static String getParameter(ServletContext context, String paramName, String defaultValue) {
+        String value = context.getInitParameter(paramName);
+        if (value == null || value.length() == 0) {
+            value = defaultValue;
+        }
+        return value;
+    }
+
+    public static String getParameter(ServletContext context, String paramName) {
+        return getParameter(context, paramName, null);
+    }
+
+    public static int getIntParameter(ServletContext context, String paramName, int defaultValue) {
+        String rawValue = context.getInitParameter(paramName);
+        try {
+            return Integer.parseInt(rawValue);
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+
+    public static int getIntParameter(ServletContext context, String paramName) {
+        return getIntParameter(context, paramName, 0);
     }
 
 }

--- a/webui/src/main/java/gov/nih/nlm/lode/servlet/SurveyTag.java
+++ b/webui/src/main/java/gov/nih/nlm/lode/servlet/SurveyTag.java
@@ -9,27 +9,20 @@ import javax.servlet.jsp.PageContext;
 import javax.servlet.jsp.tagext.TagSupport;
 
 
-public class QualtricsSurveyTag extends TagSupport {
+public class SurveyTag extends TagSupport {
 
     private static final long serialVersionUID = 1L;
 
-    private static final String TAG_FORMAT = "<iframe src=\"%s\" height=\"%dpx\" width=\"%dpx\"></iframe>\n";
-
-    public static final String URL_PARAM_NAME = "qualtrics.url";
-    public static final String HEIGHT_PARAM_NAME = "qualtrics.height";
-    public static final String WIDTH_PARAM_NAME = "qualtrics.width";
+    private static final String TAG_FORMAT = "<iframe src=\"%s\" class=\"survey\"></iframe>\n";
+    public static final String URL_PARAM_NAME = "surveyUrl";
 
     private String url;
-    private int height;
-    private int width;
 
     @Override
     public void setPageContext(PageContext context) {
         super.setPageContext(context);
         ServletContext servletContext = context.getServletContext();
         url = ServletUtils.getParameter(servletContext, URL_PARAM_NAME);
-        height = ServletUtils.getIntParameter(servletContext, HEIGHT_PARAM_NAME, 600);
-        width = ServletUtils.getIntParameter(servletContext, WIDTH_PARAM_NAME, 800);
     }
 
     @Override
@@ -37,9 +30,9 @@ public class QualtricsSurveyTag extends TagSupport {
         JspWriter out = pageContext.getOut();
         try {
             if (url != null) {
-                out.print(String.format(TAG_FORMAT, url, height, width));
+                out.print(String.format(TAG_FORMAT, url));
             } else {
-                out.print("<!-- Qualtrics survey not configured -->");
+                out.print("<!-- survey not configured -->");
             }
         } catch (IOException e) {
             throw new JspException("IOException", e);

--- a/webui/src/main/webapp/WEB-INF/lodestar-tags.tld
+++ b/webui/src/main/webapp/WEB-INF/lodestar-tags.tld
@@ -13,6 +13,11 @@
         <body-content>empty</body-content>
     </tag>
     <tag>
+        <name>qualtrics</name>
+        <tag-class>gov.nih.nlm.lode.servlet.QualtricsSurveyTag</tag-class>
+        <body-content>empty</body-content>
+    </tag>
+    <tag>
         <name>gtmnoscript</name>
         <tag-class>gov.nih.nlm.lode.servlet.GTMNoScriptTag</tag-class>
         <body-content>empty</body-content>

--- a/webui/src/main/webapp/WEB-INF/lodestar-tags.tld
+++ b/webui/src/main/webapp/WEB-INF/lodestar-tags.tld
@@ -13,8 +13,8 @@
         <body-content>empty</body-content>
     </tag>
     <tag>
-        <name>qualtrics</name>
-        <tag-class>gov.nih.nlm.lode.servlet.QualtricsSurveyTag</tag-class>
+        <name>survey</name>
+        <tag-class>gov.nih.nlm.lode.servlet.SurveyTag</tag-class>
         <body-content>empty</body-content>
     </tag>
     <tag>

--- a/webui/src/main/webapp/css/style.css
+++ b/webui/src/main/webapp/css/style.css
@@ -164,3 +164,10 @@ ul#queries_list {
   float: right;
   padding-right: 15px;
 }
+
+.survey {
+  width: 80%;
+  height: 600px;
+  margin: 0 auto;
+  display: block;
+}

--- a/webui/src/main/webapp/explore.jsp
+++ b/webui/src/main/webapp/explore.jsp
@@ -16,6 +16,7 @@
       namespaces : lodeNamespacePrefixes
     });">
     <lodestar:gtmnoscript/>
+    <lodestar:qualtrics/>
     <div class="skipnav"><a href="#data-explorer-content" class="skipnav">Skip Navigation</a></div>
     <div class="header">
       <%@ include file="internal/header.html" %>

--- a/webui/src/main/webapp/explore.jsp
+++ b/webui/src/main/webapp/explore.jsp
@@ -16,7 +16,6 @@
       namespaces : lodeNamespacePrefixes
     });">
     <lodestar:gtmnoscript/>
-    <lodestar:qualtrics/>
     <div class="skipnav"><a href="#data-explorer-content" class="skipnav">Skip Navigation</a></div>
     <div class="header">
       <%@ include file="internal/header.html" %>

--- a/webui/src/main/webapp/index.jsp
+++ b/webui/src/main/webapp/index.jsp
@@ -14,6 +14,7 @@
 
     <body>
       <lodestar:gtmnoscript/>
+      <lodestar:qualtrics/>
       <div class="skipnav"><a class="skipnav" href="#main">Skip Navigation</a>
       </div>
       <div class="header">

--- a/webui/src/main/webapp/index.jsp
+++ b/webui/src/main/webapp/index.jsp
@@ -14,11 +14,13 @@
 
     <body>
       <lodestar:gtmnoscript/>
-      <lodestar:qualtrics/>
       <div class="skipnav"><a class="skipnav" href="#main">Skip Navigation</a>
       </div>
       <div class="header">
         <%@ include file="internal/header.html" %>
+      </div>
+      <div class="container-fluid">
+        <lodestar:survey/>
       </div>
       <div class="container-fluid">
         <div id="meshTabContent" class="tab-content">

--- a/webui/src/main/webapp/internal/header.html
+++ b/webui/src/main/webapp/internal/header.html
@@ -31,7 +31,7 @@
         <ul id="meshTab" class="nav nav-tabs pull-left" role="navigation">
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-              <strong>Databases</strong>
+              <strong>Products and Services</strong>
               <b class="caret"></b>
             </a>
             <ul class="dropdown-menu">
@@ -39,63 +39,48 @@
                 <a href="https://www.ncbi.nlm.nih.gov/pubmed/">PubMed/MEDLINE</a>
               </li>
               <li>
-                <a href="https://meshb.nlm.nih.gov/">MeSH</a>
+                <a href="https://meshb.nlm.nih.gov/search">MeSH</a>
               </li>
               <li>
                 <a href="https://www.nlm.nih.gov/research/umls/">UMLS</a>
               </li>
               <li>
-                <a href="https://clinicaltrials.gov/">ClinicalTrials.gov</a>
+                <a href="https://medlineplus.gov">MedlinePlus</a>
               </li>
               <li>
-                <a href="https://www.medlineplus.gov/">MedlinePlus</a>
+                <a href="https://www.locatorplus.gov/">LocatorPlus</a>
               </li>
               <li>
-                <a href="http://toxnet.nlm.nih.gov/">TOXNET</a>
+                <a href="https://collections.nlm.nih.gov/">Digital Collections</a>
               </li>
               <li>
-                <a href="https://www.nlm.nih.gov/hmd/ihm/">Images from the History of Medicine</a>
-              </li>
-              <li>
-                <a href="http://collections.nlm.nih.gov/">Digital Collections</a>
-              </li>
-              <li>
-                <a href="http://locatorplus.gov">LocatorPlus</a>
-              </li>
-              <li>
-                <a href="https://wwwcf2.nlm.nih.gov/nlm_eresources/eresources/search_database.cfm">All NLM Databases &amp; APIs</a>
+                <a href="https://eresources.nlm.nih.gov/nlm_eresources/">All Products and Services</a>
               </li>
             </ul>
           </li>
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-              <strong>Find, Read, Learn</strong>
+              <strong>Resources for You</strong>
               <b class="caret"></b>
             </a>
             <ul class="dropdown-menu">
               <li>
-                <a href="https://www.ncbi.nlm.nih.gov/pubmed/">Search biomedical literature</a>
+                <a href="https://www.nlm.nih.gov/portals/researchers.html">For Researchers</a>
               </li>
               <li>
-                <a href="https://www.nlm.nih.gov/medical-terms.html">Find medical terminologies</a>
+                <a href="https://www.nlm.nih.gov/portals/publishers.html">For Publishers</a>
               </li>
               <li>
-                <a href="http://locatorplus.gov/">Search NLM collections</a>
+                <a href="https://www.nlm.nih.gov/portals/librarians.html">For Librarians</a>
               </li>
               <li>
-                <a href="https://www.medlineplus.gov/healthtopics.html">Read about diseases</a>
+                <a href="https://www.nlm.nih.gov/training.html">For Educators/Trainers</a>
               </li>
               <li>
-                <a href="https://www.nlm.nih.gov/learn-about-drugs.html">Learn about drugs</a>
+                <a href="https://www.nlm.nih.gov/portals/healthcare.html">For Healthcare Professionals</a>
               </li>
               <li>
-                <a href="https://www.nlm.nih.gov/hmd/explore-history.html">Explore history</a>
-              </li>
-              <li>
-                <a href="https://clinicaltrials.gov/">Find a clinical trial</a>
-              </li>
-              <li>
-                <a href="https://www.ncbi.nlm.nih.gov/pmc/">Find free full-text articles</a>
+                <a href="https://www.nlm.nih.gov/portals/public.html">For the Public</a>
               </li>
             </ul>
           </li>
@@ -106,34 +91,22 @@
             </a>
             <ul class="dropdown-menu">
               <li>
-                <a href="https://www.nlm.nih.gov/about/index.html">About NLM</a>
+                <a href="https://www.nlm.nih.gov/readingroom/index.html">Using the Library</a>
               </li>
               <li>
-                <a href="https://www.nlm.nih.gov/hinfo.html">Health Information</a>
+                <a href="https://www.nlm.nih.gov/about/index.html">About the Library</a>
               </li>
               <li>
-                <a href="https://www.nlm.nih.gov/libserv.html">Library Catalog &amp; Services</a>
+                <a href="https://www.nlm.nih.gov/hmd/">History of Medicine</a>
               </li>
               <li>
-                <a href="https://www.nlm.nih.gov/hmd/index.html">History of Medicine</a>
-              </li>
-              <li>
-                <a href="https://www.nlm.nih.gov/onlineexhibitions.html">Online Exhibitions &amp; Digital Projects</a>
-              </li>
-              <li>
-                <a href="https://www.nlm.nih.gov/portals/publishers.html">Information for Publishers</a>
-              </li>
-              <li>
-                <a href="https://www.nlm.nih.gov/about/visitor.html">Visit the Library</a>
-              </li>
-              <li>
-                <a href="https://www.nlm.nih.gov/information-in-other-languages.html">Health Information in Other Languages</a>
+                <a href="https://www.nlm.nih.gov/about/org.html">Programs &amp; Initiatives</a>
               </li>
             </ul>
           </li>
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-              <strong>Research at NLM</strong>
+              <strong>Grants and Funding</strong>
               <b class="caret"></b>
             </a>
             <ul class="dropdown-menu">
@@ -151,35 +124,6 @@
               </li>
               <li>
                 <a href="https://www.nlm.nih.gov/healthit.html">Health Information Technology</a>
-              </li>
-            </ul>
-          </li>
-          <li class="dropdown">
-            <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-              <strong>NLM for You</strong>
-              <b class="caret"></b>
-            </a>
-            <ul class="dropdown-menu">
-              <li>
-                <a href="https://www.nlm.nih.gov/grants.html">Grants &amp; Funding</a>
-              </li>
-              <li>
-                <a href="https://www.nlm.nih.gov/healthit/meaningful_use.html">Meaningful Use Tools</a>
-              </li>
-              <li>
-                <a href="https://www.nlm.nih.gov/training.html">Training &amp; Outreach</a>
-              </li>
-              <li>
-                <a href="https://nnlm.gov/">National Network of Medical Libraries</a>
-              </li>
-              <li>
-                <a href="https://www.nlm.nih.gov/regional-activities.html">Regional Activities</a>
-              </li>
-              <li>
-                <a href="https://www.nlm.nih.gov/careers/careers.html">Careers @ NLM</a>
-              </li>
-              <li>
-                <a href="https://www.nlm.nih.gov/mobile/index.html">Mobile Gallery</a>
               </li>
             </ul>
           </li>

--- a/webui/src/main/webapp/internal/headers.jsp
+++ b/webui/src/main/webapp/internal/headers.jsp
@@ -21,7 +21,6 @@
     <div class="header">
       <%@ include file="/internal/header.html" %>
     </div>
-    <lodestar:qualtrics/>
     <div class="container-fluid">
       <div id="meshTabContent" class="tab-content">
         <div class="tab-pane fade in active" id="home">

--- a/webui/src/main/webapp/internal/headers.jsp
+++ b/webui/src/main/webapp/internal/headers.jsp
@@ -21,6 +21,7 @@
     <div class="header">
       <%@ include file="/internal/header.html" %>
     </div>
+    <lodestar:qualtrics/>
     <div class="container-fluid">
       <div id="meshTabContent" class="tab-content">
         <div class="tab-pane fade in active" id="home">

--- a/webui/src/main/webapp/query.jsp
+++ b/webui/src/main/webapp/query.jsp
@@ -13,6 +13,7 @@
 
   <body onload="$('#sparql-content').sparql({namespaces : lodeNamespacePrefixes, inference: true});">
     <lodestar:gtmnoscript/>
+    <lodestar:qualtrics/>
     <div class="skipnav"><a href="#sparql-content" class="skipnav">Skip Navigation</a></div>
     <div class="header">
       <%@ include file="/internal/header.html" %>

--- a/webui/src/main/webapp/query.jsp
+++ b/webui/src/main/webapp/query.jsp
@@ -13,7 +13,6 @@
 
   <body onload="$('#sparql-content').sparql({namespaces : lodeNamespacePrefixes, inference: true});">
     <lodestar:gtmnoscript/>
-    <lodestar:qualtrics/>
     <div class="skipnav"><a href="#sparql-content" class="skipnav">Skip Navigation</a></div>
     <div class="header">
       <%@ include file="/internal/header.html" %>

--- a/webui/src/test/java/gov/nih/nlm/lode/tests/QueryTest.java
+++ b/webui/src/test/java/gov/nih/nlm/lode/tests/QueryTest.java
@@ -171,7 +171,7 @@ public class QueryTest extends LodeBaseTest {
 
         int numMatched = 0;
         List<WebElement> rows = findElements(By.cssSelector(FOR_LODESTAR_RESULT_ROWS));
-        assertEquals(rows.size(), 49);
+        assertEquals(rows.size(), 50);
         for (WebElement row : rows) {
             WebElement link = row.findElement(By.xpath("td[1]/span/a"));
             String linktext = link.getText();

--- a/webui/src/test/java/gov/nih/nlm/lode/tests/TestGTMScriptTag.java
+++ b/webui/src/test/java/gov/nih/nlm/lode/tests/TestGTMScriptTag.java
@@ -13,7 +13,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockPageContext;
 import org.springframework.mock.web.MockServletContext;
 import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import gov.nih.nlm.lode.servlet.GTMNoScriptTag;
@@ -24,11 +24,11 @@ public class TestGTMScriptTag {
     /* A fake GTM code to test */
     private static final String GTM_TESTCODE = "GTM-PPP9999";
 
-    MockHttpServletResponse response;
+    private MockHttpServletResponse response;
     private MockServletContext servletContext;
     private MockPageContext pageContext;
 
-    @BeforeTest(alwaysRun = true)
+    @BeforeMethod(alwaysRun = true)
     public void setUp() {
         MockHttpServletRequest request = new MockHttpServletRequest();
         response = new MockHttpServletResponse();
@@ -42,7 +42,6 @@ public class TestGTMScriptTag {
         servletContext = null;
         pageContext = null;
     }
-
 
     @Test(groups="unit")
     public void testGTMScriptTag() throws JspException, UnsupportedEncodingException {

--- a/webui/src/test/java/gov/nih/nlm/lode/tests/TestGTMScriptTag.java
+++ b/webui/src/test/java/gov/nih/nlm/lode/tests/TestGTMScriptTag.java
@@ -1,6 +1,7 @@
 package gov.nih.nlm.lode.tests;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.UnsupportedEncodingException;
@@ -15,43 +16,38 @@ import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import gov.nih.nlm.lode.servlet.GTMScriptTag;
 import gov.nih.nlm.lode.servlet.GTMNoScriptTag;
+import gov.nih.nlm.lode.servlet.GTMScriptTag;
 
 public class TestGTMScriptTag {
-
-    private String previousGtmCode = null;
 
     /* A fake GTM code to test */
     private static final String GTM_TESTCODE = "GTM-PPP9999";
 
-    /* The property value that GTMScriptTag will look for */
-    private static final String GTM_PROPERTY = "meshrdf.gtmcode";
+    MockHttpServletResponse response;
+    private MockServletContext servletContext;
+    private MockPageContext pageContext;
 
     @BeforeTest(alwaysRun = true)
     public void setUp() {
-        previousGtmCode = System.getProperty(GTM_PROPERTY);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        servletContext = new MockServletContext();
+        pageContext = new MockPageContext(servletContext, request, response);
     }
 
     @AfterTest(alwaysRun = true)
     public void tearDown() {
-        if (null == previousGtmCode) {
-            System.clearProperty(GTM_PROPERTY);
-        } else {
-            System.setProperty(GTM_PROPERTY, previousGtmCode);
-        }
+        response = null;
+        servletContext = null;
+        pageContext = null;
     }
+
 
     @Test(groups="unit")
     public void testGTMScriptTag() throws JspException, UnsupportedEncodingException {
         // stuff to use in test
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        MockServletContext servletContext = new MockServletContext();
-        MockPageContext pageContext = new MockPageContext(servletContext, request, response);
-
-        // Set the tag
-        System.setProperty("meshrdf.gtmcode", GTM_TESTCODE);
+        servletContext.addInitParameter(GTMScriptTag.GTM_PARAM_NAME, GTM_TESTCODE);
 
         // test
         GTMScriptTag tag = new GTMScriptTag();
@@ -66,15 +62,6 @@ public class TestGTMScriptTag {
 
     @Test(groups="unit")
     public void testGTMScriptTagNoCode() throws JspException, UnsupportedEncodingException {
-        // stuff to use in test
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        MockServletContext servletContext = new MockServletContext();
-        MockPageContext pageContext = new MockPageContext(servletContext, request, response);
-
-        // Clear the tag
-        System.clearProperty(GTM_PROPERTY);
-
         // test
         GTMScriptTag tag = new GTMScriptTag();
         tag.setPageContext(pageContext);
@@ -88,14 +75,8 @@ public class TestGTMScriptTag {
 
     @Test(groups="unit")
     public void testGTMNoScriptTag() throws JspException, UnsupportedEncodingException {
-        // stuff to use in test
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        MockServletContext servletContext = new MockServletContext();
-        MockPageContext pageContext = new MockPageContext(servletContext, request, response);
-
         // Set the tag
-        System.setProperty("meshrdf.gtmcode", GTM_TESTCODE);
+        servletContext.addInitParameter(GTMScriptTag.GTM_PARAM_NAME, GTM_TESTCODE);
 
         // test
         GTMNoScriptTag tag = new GTMNoScriptTag();
@@ -110,14 +91,8 @@ public class TestGTMScriptTag {
 
     @Test(groups="unit")
     public void testGTMNoScriptTagNoCode() throws JspException, UnsupportedEncodingException {
-        // stuff to use in test
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        MockServletContext servletContext = new MockServletContext();
-        MockPageContext pageContext = new MockPageContext(servletContext, request, response);
-
-        // Clear the tag
-        System.clearProperty(GTM_PROPERTY);
+        // Set the tag
+        servletContext.addInitParameter(GTMScriptTag.GTM_PARAM_NAME, "");
 
         // test
         GTMNoScriptTag tag = new GTMNoScriptTag();

--- a/webui/src/test/java/gov/nih/nlm/lode/tests/TestQualtricsSurveyTag.java
+++ b/webui/src/test/java/gov/nih/nlm/lode/tests/TestQualtricsSurveyTag.java
@@ -47,7 +47,7 @@ public class TestQualtricsSurveyTag {
         tag.doStartTag();
 
         String content = response.getContentAsString();
-        assertThat(content, equalTo(""));
+        assertThat(content, equalTo("<!-- Qualtrics survey not configured -->"));
     }
 
     @Test(groups = "unit")
@@ -59,7 +59,7 @@ public class TestQualtricsSurveyTag {
         tag.doStartTag();
 
         String content = response.getContentAsString();
-        assertThat(content, equalTo(""));
+        assertThat(content, equalTo("<!-- Qualtrics survey not configured -->"));
     }
 
     @Test(groups = "unit")

--- a/webui/src/test/java/gov/nih/nlm/lode/tests/TestQualtricsSurveyTag.java
+++ b/webui/src/test/java/gov/nih/nlm/lode/tests/TestQualtricsSurveyTag.java
@@ -13,7 +13,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockPageContext;
 import org.springframework.mock.web.MockServletContext;
 import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import gov.nih.nlm.lode.servlet.QualtricsSurveyTag;
@@ -25,7 +25,7 @@ public class TestQualtricsSurveyTag {
     private MockServletContext servletContext;
     private MockPageContext pageContext;
 
-    @BeforeTest(alwaysRun = true)
+    @BeforeMethod(alwaysRun = true)
     public void setUp() {
         MockHttpServletRequest request = new MockHttpServletRequest();
         response = new MockHttpServletResponse();

--- a/webui/src/test/java/gov/nih/nlm/lode/tests/TestQualtricsSurveyTag.java
+++ b/webui/src/test/java/gov/nih/nlm/lode/tests/TestQualtricsSurveyTag.java
@@ -1,0 +1,98 @@
+package gov.nih.nlm.lode.tests;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.UnsupportedEncodingException;
+
+import javax.servlet.jsp.JspException;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockPageContext;
+import org.springframework.mock.web.MockServletContext;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import gov.nih.nlm.lode.servlet.QualtricsSurveyTag;
+
+
+public class TestQualtricsSurveyTag {
+
+    private MockHttpServletResponse response;
+    private MockServletContext servletContext;
+    private MockPageContext pageContext;
+
+    @BeforeTest(alwaysRun = true)
+    public void setUp() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        servletContext = new MockServletContext();
+        pageContext = new MockPageContext(servletContext, request, response);
+    }
+
+    @AfterTest(alwaysRun = true)
+    public void tearDown() {
+        response = null;
+        servletContext = null;
+        pageContext = null;
+    }
+
+    @Test(groups = "unit")
+    public void testNullUrl() throws JspException, UnsupportedEncodingException {
+        QualtricsSurveyTag tag = new QualtricsSurveyTag();
+        tag.setPageContext(pageContext);
+        tag.doStartTag();
+
+        String content = response.getContentAsString();
+        assertThat(content, equalTo(""));
+    }
+
+    @Test(groups = "unit")
+    public void testEmptyUrl() throws JspException, UnsupportedEncodingException {
+        servletContext.addInitParameter(QualtricsSurveyTag.URL_PARAM_NAME, "");
+
+        QualtricsSurveyTag tag = new QualtricsSurveyTag();
+        tag.setPageContext(pageContext);
+        tag.doStartTag();
+
+        String content = response.getContentAsString();
+        assertThat(content, equalTo(""));
+    }
+
+    @Test(groups = "unit")
+    public void testUrlDefaultWidthHeight() throws JspException, UnsupportedEncodingException {
+        String expectedUrl = "https://short-survey.com/toehunthehune";
+        servletContext.addInitParameter(QualtricsSurveyTag.URL_PARAM_NAME, expectedUrl);
+
+        QualtricsSurveyTag tag = new QualtricsSurveyTag();
+        tag.setPageContext(pageContext);
+        tag.doStartTag();
+
+        String content = response.getContentAsString();
+
+        assertThat(content, containsString(String.format("src=\"%s\"", expectedUrl)));
+        assertThat(content, containsString("width=\"800px\""));
+        assertThat(content, containsString("height=\"600px\""));
+    }
+
+    @Test(groups = "unit")
+    public void testOverrideWidthHeight() throws JspException, UnsupportedEncodingException {
+        String expectedUrl = "https://short-survey.com/ZZEOTUHEG8G89";
+        servletContext.addInitParameter(QualtricsSurveyTag.URL_PARAM_NAME, expectedUrl);
+        servletContext.addInitParameter(QualtricsSurveyTag.WIDTH_PARAM_NAME, "677");
+        servletContext.addInitParameter(QualtricsSurveyTag.HEIGHT_PARAM_NAME, "877");
+
+        QualtricsSurveyTag tag = new QualtricsSurveyTag();
+        tag.setPageContext(pageContext);
+        tag.doStartTag();
+
+        String content = response.getContentAsString();
+
+        assertThat(content, containsString(String.format("src=\"%s\"", expectedUrl)));
+        assertThat(content, containsString("width=\"677px\""));
+        assertThat(content, containsString("height=\"877px\""));
+    }
+}

--- a/webui/src/test/java/gov/nih/nlm/lode/tests/TestSurveyTag.java
+++ b/webui/src/test/java/gov/nih/nlm/lode/tests/TestSurveyTag.java
@@ -16,10 +16,10 @@ import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import gov.nih.nlm.lode.servlet.QualtricsSurveyTag;
+import gov.nih.nlm.lode.servlet.SurveyTag;
 
 
-public class TestQualtricsSurveyTag {
+public class TestSurveyTag {
 
     private MockHttpServletResponse response;
     private MockServletContext servletContext;
@@ -42,57 +42,38 @@ public class TestQualtricsSurveyTag {
 
     @Test(groups = "unit")
     public void testNullUrl() throws JspException, UnsupportedEncodingException {
-        QualtricsSurveyTag tag = new QualtricsSurveyTag();
+        SurveyTag tag = new SurveyTag();
         tag.setPageContext(pageContext);
         tag.doStartTag();
 
         String content = response.getContentAsString();
-        assertThat(content, equalTo("<!-- Qualtrics survey not configured -->"));
+        assertThat(content, equalTo("<!-- survey not configured -->"));
     }
 
     @Test(groups = "unit")
     public void testEmptyUrl() throws JspException, UnsupportedEncodingException {
-        servletContext.addInitParameter(QualtricsSurveyTag.URL_PARAM_NAME, "");
+        servletContext.addInitParameter(SurveyTag.URL_PARAM_NAME, "");
 
-        QualtricsSurveyTag tag = new QualtricsSurveyTag();
+        SurveyTag tag = new SurveyTag();
         tag.setPageContext(pageContext);
         tag.doStartTag();
 
         String content = response.getContentAsString();
-        assertThat(content, equalTo("<!-- Qualtrics survey not configured -->"));
+        assertThat(content, equalTo("<!-- survey not configured -->"));
     }
 
     @Test(groups = "unit")
     public void testUrlDefaultWidthHeight() throws JspException, UnsupportedEncodingException {
         String expectedUrl = "https://short-survey.com/toehunthehune";
-        servletContext.addInitParameter(QualtricsSurveyTag.URL_PARAM_NAME, expectedUrl);
+        servletContext.addInitParameter(SurveyTag.URL_PARAM_NAME, expectedUrl);
 
-        QualtricsSurveyTag tag = new QualtricsSurveyTag();
+        SurveyTag tag = new SurveyTag();
         tag.setPageContext(pageContext);
         tag.doStartTag();
 
         String content = response.getContentAsString();
 
         assertThat(content, containsString(String.format("src=\"%s\"", expectedUrl)));
-        assertThat(content, containsString("width=\"800px\""));
-        assertThat(content, containsString("height=\"600px\""));
-    }
-
-    @Test(groups = "unit")
-    public void testOverrideWidthHeight() throws JspException, UnsupportedEncodingException {
-        String expectedUrl = "https://short-survey.com/ZZEOTUHEG8G89";
-        servletContext.addInitParameter(QualtricsSurveyTag.URL_PARAM_NAME, expectedUrl);
-        servletContext.addInitParameter(QualtricsSurveyTag.WIDTH_PARAM_NAME, "677");
-        servletContext.addInitParameter(QualtricsSurveyTag.HEIGHT_PARAM_NAME, "877");
-
-        QualtricsSurveyTag tag = new QualtricsSurveyTag();
-        tag.setPageContext(pageContext);
-        tag.doStartTag();
-
-        String content = response.getContentAsString();
-
-        assertThat(content, containsString(String.format("src=\"%s\"", expectedUrl)));
-        assertThat(content, containsString("width=\"677px\""));
-        assertThat(content, containsString("height=\"877px\""));
+        assertThat(content, containsString("class=\"survey\""));
     }
 }


### PR DESCRIPTION
* Default year is updated to 2020
* Some dependencies are updated

Features:
* Configuration via environment variables and system properties is removed in favor of Servlet context. There is a default servlet context built in `META-INF/context.xml`, but this is overridden by deployment
* The XSLT transform is updated so that it should be easier to convert from MeSH XML containing non-English labels, provided the label-lang variable is overridden in processing.
